### PR TITLE
Use getent instead of dig so that /etc/hosts is respected.

### DIFF
--- a/salticid/main.rb
+++ b/salticid/main.rb
@@ -45,9 +45,9 @@ role :jepsen do
 
   task :partition do
     sudo do
-      n3 = (getent 'ahosts', :n3).split("\n").first.split(" ").first
-      n4 = (getent 'ahosts', :n4).split("\n").first.split(" ").first
-      n5 = (getent 'ahosts', :n5).split("\n").first.split(" ").first
+      n3 = (getent 'ahosts', :n3).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
+      n4 = (getent 'ahosts', :n4).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
+      n5 = (getent 'ahosts', :n5).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
       if ['n1', 'n2'].include? name
         log "Partitioning from n3, n4 and n5."
         iptables '-A', 'INPUT', '-s', n3, '-j', 'DROP'
@@ -60,11 +60,11 @@ role :jepsen do
 
   task :partition_reject do
     sudo do
-      n1 = (getent 'ahosts', :n1).split("\n").first.split(" ").first
-      n2 = (getent 'ahosts', :n2).split("\n").first.split(" ").first
-      n3 = (getent 'ahosts', :n3).split("\n").first.split(" ").first
-      n4 = (getent 'ahosts', :n4).split("\n").first.split(" ").first
-      n5 = (getent 'ahosts', :n5).split("\n").first.split(" ").first
+      n1 = (getent 'ahosts', :n1).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
+      n2 = (getent 'ahosts', :n2).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
+      n3 = (getent 'ahosts', :n3).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
+      n4 = (getent 'ahosts', :n4).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
+      n5 = (getent 'ahosts', :n5).split("\n").reject {|line| line.start_with?("127.")}.first.split(" ").first
       if ['n1', 'n2'].include? name
         log "Partitioning from n3, n4 and n5."
         iptables '-A', 'INPUT', '-s', n3, '-j', 'REJECT'


### PR DESCRIPTION
I was setting up a 5 node test but ran into issues because `dig` will _only_ get results from a DNS server. `getent` respects the `/etc/hosts` file but falls back to DNS.

I'm really new to salticid, so this is copy-pasta like the dig commands were before.
