### PR TITLE
Use getent rather than dig.

### DIFF
--- a/src/jepsen/control/net.clj
+++ b/src/jepsen/control/net.clj
@@ -1,7 +1,8 @@
 (ns jepsen.control.net
   "Network control functions."
   (:refer-clojure :exclude [partition])
-  (:use jepsen.control))
+  (:use jepsen.control)
+  (:require [clojure.string :as str]))
 
 (def hosts-map {:n1 "n1"
               :n2 "n2"
@@ -31,7 +32,14 @@
 (defn ip
   "Look up an ip for a hostname"
   [host]
-  (exec :dig :+short :+search host))
+  ; getent output is of the form:
+  ; 74.125.239.39   STREAM host.com
+  ; 74.125.239.39   DGRAM
+  ; ...
+  (first (str/split (->> (exec :getent :ahosts host)
+                         (str/split-lines)
+                         (first))
+                    #"\s+")))
 
 (defn cut-random-link
   "Cuts a random link to any of nodes."


### PR DESCRIPTION
I saw the following remote error message when Jepsen tried to partition the
cluster:

'DROP' unknown argument, see iptables -h for usage.

The command being executed was:

"sudo -S -u root bash -c "cd /; iptables -A INPUT -s -j DROP"

The problem here was that the argument to -s was nil.

I "dug" a bit deeper and found that the `dig` command (used in jepsen.control.net/ip) does not search /etc/hosts:

http://superuser.com/questions/305939/bash-lookup-an-ip-for-a-host-name-including-etc-hosts-in-search

This commit uses getent instead of dig, which searches looks up hosts by both
/etc/hosts and DNS. I verified that this correctly returns non-nil results.

This is my first time using Clojure; please feel free to comment on style problems.
