### PR TITLE
Sanity check app-names given on command line.

### DIFF
--- a/src/jepsen/bin.clj
+++ b/src/jepsen/bin.clj
@@ -82,7 +82,8 @@
           port  (get opts :port nil)
           ]
 
-      (when (empty? app-names)
+      (when (or (empty? app-names)
+                (not-every? true? (map (partial contains? app-map) app-names)))
         (println usage)
         (println "Available apps:")
         (dorun (map println (sort (keys app-map))))


### PR DESCRIPTION
I tried running `lein run redis`, as in the blog [post](http://aphyr.com/posts/283-call-me-maybe-redis), and got a cryptic stack trace:

```
java.lang.NullPointerException
        at jepsen.set_app$apps$fn__119.invoke(set_app.clj:118)
        at clojure.core$map$fn__4245.invoke(core.clj:2559)
        ...
```

This issue was that app-fn was null, since apparently "redis" is no longer in bin.clj's app-map.

This commit sanity checks command line arguments.
