### PR TITLE
Redis salticid setup fixes

### DIFF
--- a/salticid/redis.rb
+++ b/salticid/redis.rb
@@ -30,7 +30,7 @@ role :redis do
   task :sentinel do
     sudo do
       echo "port 26379
-sentinel monitor mymaster #{dig '+short', name} 6379 3
+sentinel monitor mymaster #{name} 6379 3
 sentinel down-after-milliseconds mymaster 5000
 sentinel failover-timeout mymaster 900000
 sentinel parallel-syncs mymaster 5", to: '/opt/redis/sentinel.config'


### PR DESCRIPTION
Remove deprecated "can-failover" configuration.

Refer to redis master by hostname, not necessary to use IP address.
