### PR TITLE
package test utilities in main artefact

### DIFF
--- a/datomic/test/jepsen/system/datomic_test.clj
+++ b/datomic/test/jepsen/system/datomic_test.clj
@@ -1,7 +1,7 @@
 (ns jepsen.system.datomic-test
   (:use jepsen.system.datomic
         jepsen.core
-        jepsen.core-test
+        jepsen.tests
         clojure.test
         clojure.pprint)
   (:require [clojure.string   :as str]

--- a/elasticsearch/test/jepsen/system/elasticsearch_test.clj
+++ b/elasticsearch/test/jepsen/system/elasticsearch_test.clj
@@ -1,7 +1,7 @@
 (ns jepsen.system.elasticsearch-test
   (:use jepsen.system.elasticsearch
         jepsen.core
-        jepsen.core-test
+        jepsen.tests
         clojure.test
         clojure.pprint)
   (:require [clojure.string   :as str]

--- a/etcd/test/jepsen/system/etcd_test.clj
+++ b/etcd/test/jepsen/system/etcd_test.clj
@@ -1,7 +1,7 @@
 (ns jepsen.system.etcd-test
   (:use jepsen.system.etcd
         jepsen.core
-        jepsen.core-test
+        jepsen.tests
         clojure.test
         clojure.pprint)
   (:require [clojure.string   :as str]

--- a/rabbitmq/test/jepsen/system/rabbitmq_test.clj
+++ b/rabbitmq/test/jepsen/system/rabbitmq_test.clj
@@ -1,7 +1,7 @@
 (ns jepsen.system.rabbitmq-test
   (:use jepsen.system.rabbitmq
         jepsen.core
-        jepsen.core-test
+        jepsen.tests
         clojure.test
         clojure.pprint)
   (:require [clojure.string   :as str]

--- a/test/jepsen/core_test.clj
+++ b/test/jepsen/core_test.clj
@@ -5,61 +5,20 @@
         clojure.tools.logging)
   (:require [jepsen.os :as os]
             [jepsen.db :as db]
+            [jepsen.tests :as tst]
             [jepsen.control :as control]
             [jepsen.client :as client]
             [jepsen.generator :as gen]
             [jepsen.model :as model]
             [jepsen.checker :as checker]))
 
-(def noop-test
-  "Boring test stub"
-  {:nodes     [:n1 :n2 :n3 :n4 :n5]
-   :os        os/noop
-   :db        db/noop
-   :client    client/noop
-   :nemesis   client/noop
-   :generator gen/void
-   :model     model/noop
-   :checker   checker/linearizable})
-
-(defn atom-db
-  "Wraps an atom as a database."
-  [state]
-  (reify db/DB
-    (setup!    [db test node] (reset! state 0))
-    (teardown! [db test node] (reset! state :done))))
-
-(defn atom-client
-  "A CAS client which uses an atom for state."
-  [state]
-  (reify client/Client
-    (setup!    [this test node] this)
-    (teardown! [this test])
-    (invoke!   [this test op]
-      (case (:f op)
-        :write (do (reset! state   (:value op))
-                   (assoc op :type :ok))
-
-        :cas   (let [[cur new] (:value op)]
-                 (try
-                   (swap! state (fn [v]
-                                  (if (= v cur)
-                                    new
-                                    (throw (RuntimeException. "CAS failed")))))
-                   (assoc op :type :ok)
-                   (catch RuntimeException e
-                     (assoc op :type :fail))))
-
-        :read  (assoc op :type :ok
-                      :value @state)))))
-
 (deftest basic-cas-test
   (let [state (atom nil)
-        db    (atom-db state)
+        db    (tst/atom-db state)
         n     10
-        test  (run! (assoc noop-test
-                           :db         (atom-db state)
-                           :client     (atom-client state)
+        test  (run! (assoc tst/noop-test
+                           :db         (tst/atom-db state)
+                           :client     (tst/atom-client state)
                            :generator  (->> gen/cas
                                             (gen/limit n)
                                             (gen/nemesis gen/void))
@@ -72,7 +31,7 @@
         db-startups  (atom {})
         db-teardowns (atom {})
         db-primaries (atom [])
-        test (run! (assoc noop-test
+        test (run! (assoc tst/noop-test
                           :os (reify os/OS
                                 (setup! [_ test node]
                                   (swap! os-startups assoc node
@@ -109,7 +68,7 @@
   ; Workers should only consume n ops even when failing.
   (let [invocations (atom 0)
         n 30]
-    (run! (assoc noop-test
+    (run! (assoc tst/noop-test
                  :client (reify client/Client
                            (setup! [c _ _] c)
                            (invoke! [_ _ _]

--- a/test/jepsen/nemesis_test.clj
+++ b/test/jepsen/nemesis_test.clj
@@ -6,7 +6,7 @@
             [jepsen.control :as c]
             [jepsen.control.net :as net]
             [jepsen.util :refer [meh]]
-            [jepsen.core-test :refer [noop-test]]))
+            [jepsen.tests :refer [noop-test]]))
 
 (defn edges
   "A map of nodes to the set of nodes they can ping"

--- a/test/jepsen/store_test.clj
+++ b/test/jepsen/store_test.clj
@@ -5,7 +5,8 @@
         jepsen.store)
   (:require [jepsen.core-test :as core-test]
             [jepsen.core :as core]
-            [multiset.core :as multiset]))
+            [multiset.core :as multiset]
+            [jepsen.tests :refer [noop-test]))
 
 (deftest roundtrip-test
   (delete! "store-test")


### PR DESCRIPTION
hoop-test (and atom-db. atom-caw-client)  are used by tests. By moving them to src/ we ensure they are part of packaged jepsen artifact which means people can write jepsen tests in their own projects and depend on a
single artifact.
