### PR TITLE
Fix for partitioning a single node

### DIFF
--- a/src/jepsen/nemesis.clj
+++ b/src/jepsen/nemesis.clj
@@ -34,6 +34,12 @@
   [coll]
   (split-at (Math/floor (/ (count coll) 2)) coll))
 
+(defn split-one
+  "Split one node off from the rest"
+  [coll]
+  (let [loner (rand-nth coll)]
+    [[loner] (remove (fn [x] (= x loner)) coll)]))
+
 (defn complete-grudge
   "Takes a collection of components (collections of nodes), and computes a
   grudge such that no node can talk to any nodes outside its partition."
@@ -96,9 +102,8 @@
 (defn partition-random-node
   "Isolates a single node from the rest of the network."
   []
-  (partitioner (fn [nodes]
-                 (let [loner (rand-nth nodes)]
-                   (complete-grudge [[list loner] (remove loner nodes)])))))
+  (partitioner (comp complete-grudge split-one)))
+
 
 (defn set-time!
   "Set the local node time in POSIX seconds."


### PR DESCRIPTION
Previous code was creating a grudge like:
INFO  jepsen.nemesis - {:n1 #{#<clojure.lang.PersistentList$1@1fbc22da>}, :n2 #{#<clojure.lang.PersistentList$1@1fbc22da>}, :n4 #{#<clojure.lang.PersistentList$1@1fbc22da>}, :n3 #{#<clojure.lang.PersistentList$1@1fbc22da>}, #<clojure.lang.PersistentList$1@1fbc22da> #{:n3 :n4 :n2 :n1}, :n5 #{#<clojure.lang.PersistentList$1@1fbc22da>}}

Perhaps it's an issue with clojure versions? I'm using 1.5.1 here. Ignore if thats the case.
