### PR TITLE
Make debian/install also use :--force-yes when no version is specified

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -95,7 +95,7 @@
       (when-not (empty? missing)
         (c/su
           (info "Installing" missing)
-          (apply c/exec :apt-get :install :-y missing))))))
+          (apply c/exec :apt-get :install :-y :--force-yes missing))))))
 
 (defn add-key!
   "Receives an apt key from the given keyserver."


### PR DESCRIPTION
When specific versions of packages are specified, debian/install
uses :--force-yes, but that is not the case when no version is specified.
This leads to installations failing for the latter case with:
"There are problems and -y was used without --force-yes"

This just adds the missing parameter.