### PR TITLE
Cockroach: --logtostderr needs no arguments

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/auto.clj
+++ b/cockroachdb/src/jepsen/cockroach/auto.clj
@@ -172,7 +172,7 @@
     :--]
    cockroach-start-arguments
    extra-args
-   [:--logtostderr :true :>> errlog (c/lit "2>&1")]))
+   [:--logtostderr :>> errlog (c/lit "2>&1")]))
 
 (defn runcmd
   "The command to run cockroach for a given test"


### PR DESCRIPTION
`--logtostderr true` no longer works due to a change in an upstream library.