### PR TITLE
cockroach: update use of SPLIT AT

### DIFF
--- a/cockroachdb/full.sh
+++ b/cockroachdb/full.sh
@@ -1,5 +1,5 @@
 lein do clean, run test \
-  --tarball http://aphyr.com/media/cockroach-2016-10-27.tar.bz2 \
+  --tarball http://aphyr.com/media/cockroach-2017-03-30.tar.bz2 \
   --username admin \
   --nodes-file ~/nodes \
   --test sets \

--- a/cockroachdb/src/jepsen/cockroach/client.clj
+++ b/cockroachdb/src/jepsen/cockroach/client.clj
@@ -303,7 +303,7 @@
 (defn split!
   "Split the given table at the given key."
   [conn table k]
-  (query conn [(str "alter table " (name table) " split at ("
+  (query conn [(str "alter table " (name table) " split at values ("
                     (if (number? k)
                       k
                       (str "'" k "'"))

--- a/cockroachdb/src/jepsen/cockroach/runner.clj
+++ b/cockroachdb/src/jepsen/cockroach/runner.clj
@@ -85,7 +85,7 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos? "Must be positive"]]
 
-   (jc/tarball-opt "https://binaries.cockroachdb.com/cockroach-beta-20160829.linux-amd64.tgz")])
+   (jc/tarball-opt "https://binaries.cockroachdb.com/cockroach-beta-20170330.linux-amd64.tgz")])
 
 (defn log-test
   [t]


### PR DESCRIPTION
The syntax of SPLIT AT is being changed in
https://github.com/cockroachdb/cockroach/pull/14281.

Not sure when we should merge this - as soon as the PR above goes in, or whenever we have a beta release that incorporates it..
CC @knz