### PR TITLE
Fix minor doc typos

### DIFF
--- a/doc/checker.md
+++ b/doc/checker.md
@@ -144,7 +144,7 @@ Everything looks good! ヽ(‘ー`)ノ
 ```
 
 The last operation in this history was a write of `1`, and sure enough, the
-checker's final valu eis also `1`. This history was linearizable.
+checker's final value is also `1`. This history was linearizable.
 
 ## Multiple checkers
 
@@ -166,7 +166,7 @@ $ lein run test
 $ open store/latest/latency-raw.png
 ```
 
-We can also generate HTML visualizations of the history. Let's add the `jepsen.checker.tiemline` namespace:
+We can also generate HTML visualizations of the history. Let's add the `jepsen.checker.timeline` namespace:
 
 ```clj
 (ns jepsen.etcdemo

--- a/doc/client.md
+++ b/doc/client.md
@@ -267,7 +267,7 @@ integers and null, we can get away with using Java's built-in
 ```
 
 Note that we only call parseLong when our string is truthy--using `(when s
-...)`. If `when` doesn't match, it'll return nil, which lets us pass through
+...)`. If `when` doesn't match, it'll return `nil`, which lets us pass through
 `nil` values transparently.
 
 ```bash
@@ -283,7 +283,7 @@ Seems reasonable! Only one type of operation left to implement: compare-and-set.
 
 ## Compare and set
 
-we'll finish the client by adding compare-and-set to the mix:
+We'll finish the client by adding compare-and-set to the mix:
 
 ```clj
       (gen/mix [r w cas])
@@ -293,7 +293,7 @@ Handling CaS is a little trickier. Verschlimmbesserung gives us a `cas!`
 function, which takes a connection, key, old value, and new value. `cas!` sets
 the key to the new value if and only if the old value matches what's currently
 there, and returns a detailed response map. If the CaS fails, it returns false.
-We can use that to determine the `:type` of the cas operation.
+We can use that to determine the `:type` of the CaS operation.
 
 ```clj
     (invoke! [this test op]
@@ -325,7 +325,7 @@ clojure.lang.ExceptionInfo: throw+: {:errorCode 100, :message "Key not found", :
 ```
 
 A slight hiccup: if we try to CaS the key before it's written,
-verschlimmbesserung will throw an exception complaining (quite sensibly!) that
+Verschlimmbesserung will throw an exception complaining (quite sensibly!) that
 we can't alter something that doesn't exist. This won't cause our test to
 return false positives--Jepsen will interpret the exception as an indeterminate
 `:info` result, and allow that it might or might not have taken place. However,

--- a/doc/db.md
+++ b/doc/db.md
@@ -7,7 +7,7 @@ in a CI system, parameterize database configuration, run multiple tests
 back-to-back with a clean slate, and so on.
 
 In `src/jepsen/etcdemo.clj`, we'll require the `jepsen.db`, `jepsen.control`,
-jepsen.control.util`, and `jepsen.os.debian` namespaces, aliasing each to a
+`jepsen.control.util`, and `jepsen.os.debian` namespaces, aliasing each to a
 short name. `clojure.string` will help us build configuration strings for etcd.
 We'll also pull in every function from `clojure.tools.logging`, giving us log
 functions like `info`, `warn`, etc.
@@ -245,8 +245,8 @@ accidentally read data from our current run.
         (c/exec :rm :-rf dir)))))
 ```
 
-We use `jepsen.control/exec` to run a shell command: rm
--rf. Jepsen automatically binds `exec` to operate on the `node` being set up
+We use `jepsen.control/exec` to run a shell command: `rm -rf`. 
+Jepsen automatically binds `exec` to operate on the `node` being set up
 during `db/setup!`, but we can connect to arbitrary nodes if we need to. Note
 that `exec` can take any mixture of strings, numbers, keywords--it'll convert
 them to strings and perform appropriate shell escaping. You can use

--- a/doc/refining.md
+++ b/doc/refining.md
@@ -33,7 +33,7 @@ java.net.SocketTimeoutException: Read timed out
   ...
 ```
 
-... and that process' operation is converted to an :info message, because we
+... and that process' operation is converted to an `:info` message, because we
 can't tell if it succeeded or failed. However, *idempotent* operations, like
 reads, leave the state of the system unchanged. It doesn't *matter* whether
 they succeed or fail, because the effects are equivalent. We can therefore
@@ -62,7 +62,7 @@ safely convert crashed reads to failed reads, and improve checker performance.
 
 Better yet--we can get rid of all the exception stacktrace noise in the logs if
 we catch socket timeouts on all three paths at once. We'll handle not-found
-errors there too, even though they only happen on :cas ops--it keeps the code a
+errors there too, even though they only happen on `:cas` ops--it keeps the code a
 little cleaner.
 
 ```clj
@@ -132,8 +132,8 @@ single-key test into one which operates on multiple keys. The
             [jepsen.os.debian :as debian]))
 ```
 
-We have a generator that emits operations on a single key, like {:type :invoke,
-:f :write, :value 3}. We want to lift that to an operation that writes
+We have a generator that emits operations on a single key, like `{:type :invoke,
+:f :write, :value 3}`. We want to lift that to an operation that writes
 *multiple* keys. Instead of `:value v`, we want `:value [key v]`.
 
 ```clj


### PR DESCRIPTION
Trivial doc fixes, mostly adding missing back-ticks.