### PR TITLE
Fix crashing omission in tutorial

### DIFF
--- a/doc/refining.md
+++ b/doc/refining.md
@@ -170,7 +170,7 @@ keys.
             :read (let [value (-> conn
                                   (v/get k {:quorum? true})
                                   parse-long)]
-                    (assoc op :type :ok, :value value))
+                    (assoc op :type :ok, :value (independent/tuple k value)))
 
             :write (do (v/reset! conn k v)
                        (assoc op :type, :ok))


### PR DESCRIPTION
The text says "Also note that where we modify the value--for instance, in
`:f :read`--we have to construct a special `independent/tuple` for the
key/value pair."
but the code sample omitted that, resulting in exceptions.