### PR TITLE
Expose more options to start-stop-daemon in start-daemon!

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -149,21 +149,26 @@
   "Starts a daemon process, logging stdout and stderr to the given file.
   Invokes `bin` with `args`. Options are:
 
+  :background?
+  :chdir
   :logfile
+  :make-pidfile?
+  :match-executable?
+  :match-process-name?
   :pidfile
-  :remove-pidfile?
-  :chdir"
+  :process-name"
   [opts bin & args]
   (info "starting" (.getName (file bin)))
   (apply exec :start-stop-daemon :--start
-         :--background
-         :--make-pidfile
-         (when (:remove-pidfile? opts true) :--remove-pidfile)
+         (when (:background? opts true) [:--background :--no-close])
+         (when (:make-pidfile? opts true) :--make-pidfile)
+         (when (:match-executable? opts true) [:--exec bin])
+         (when (:match-process-name? opts false)
+           [:--name (:process-name opts (.getName (file bin)))])
          :--pidfile  (:pidfile opts)
          :--chdir    (:chdir opts)
-         :--no-close
          :--oknodo
-         :--exec     bin
+         :--startas  bin
          :--
          (concat args [:>> (:logfile opts) (lit "2>&1")])))
 


### PR DESCRIPTION
@aphyr, the options being exposed are particularly useful in the context of `jepsen.mongodb.time/wrap!` where the `bin` argument to the `jepsen.control.util/start-daemon!` function doesn't match the actual process that ends up being spawned (e.g. as is the case in [`jepsen.mongodb.faketime`](https://github.com/jepsen-io/mongodb/blob/6d5d595895477a3bf1684249fbe46c931c278c34/src/jepsen/mongodb/faketime.clj#L55-L60)).

* Add a `background?` option. Defaults to true to match the previous behavior with specifying `start-stop-daemon --background --no-close`. Note that the `--no-close` option is only meaningful when the `--background` option is also specified.
  - http://man7.org/linux/man-pages/man8/start-stop-daemon.8.html
  - http://sources.debian.net/src/dpkg/1.18.24/utils/start-stop-daemon.c/#L1182-L1183
* Adds a `make-pidfile?` option. Defaults to true to match the previous behavior with specifying `start-stop-daemon --make-pidfile`. This option is useful to disable when the process being spawned is capable of forking from the main process and writing its own pidfile.
* Adds a `match-executable?` option. Defaults to true to match the previous behavior with specifying `start-stop-daemon --exec <bin>`. This option is useful to disable when the `bin` argument doesn't match the actual process that ends up being spawned.
* Adds a `match-process-name?` option. Defaults to false to match the previous behavior.
* Adds a `process-name` option. Defaults to the basename of the `bin` argument. It is only meaningful when the `match-process-name?` option is true.
* Removes the `remove-pidfile?` option. The `--remove-pidfile` option is ignored by `start-stop-daemon --start`.
  - http://man7.org/linux/man-pages/man8/start-stop-daemon.8.html
  - http://sources.debian.net/src/dpkg/1.18.24/utils/start-stop-daemon.c/#L2427-L2428