### PR TITLE
cockroach: Reduce test flakiness

### DIFF
--- a/cockroachdb/src/jepsen/cockroach/adya.clj
+++ b/cockroachdb/src/jepsen/cockroach/adya.clj
@@ -27,7 +27,7 @@
     (let [client (c/client node)]
       (locking table-created?
         (when (compare-and-set! table-created? false true)
-          (rc/with-conn [c client]
+          (c/with-conn [c client]
             (c/with-timeout
               (c/with-txn-retry
                 (j/execute! c "create table a (
@@ -43,7 +43,7 @@
 
   (invoke! [this test op]
     (c/with-exception->op op
-      (rc/with-conn [c client]
+      (c/with-conn [c client]
         (c/with-timeout
           (let [[k [a-id b-id]] (:value op)]
             (case (:f op)

--- a/cockroachdb/src/jepsen/cockroach/bank.clj
+++ b/cockroachdb/src/jepsen/cockroach/bank.clj
@@ -23,7 +23,7 @@
     (let [conn (c/client node)]
       (locking tbl-created?
         (when (compare-and-set! tbl-created? false true)
-          (rc/with-conn [c conn]
+          (c/with-conn [c conn]
             (Thread/sleep 1000)
             (c/with-txn-retry
               (j/execute! c ["drop table if exists accounts"]))
@@ -43,7 +43,7 @@
 
   (invoke! [this test op]
     (c/with-exception->op op
-      (rc/with-conn [c conn]
+      (c/with-conn [c conn]
         (c/with-timeout
           (c/with-txn-retry
             (c/with-txn [c c]
@@ -83,7 +83,7 @@
   (teardown! [this test]
     (try
       (c/with-timeout
-        (rc/with-conn [c conn]
+        (c/with-conn [c conn]
           (j/execute! c ["drop table if exists accounts"])))
       (finally
         (rc/close! conn)))))
@@ -172,7 +172,7 @@
     (let [conn (c/client node)]
       (locking tbl-created?
         (when (compare-and-set! tbl-created? false true)
-          (rc/with-conn [c conn]
+          (c/with-conn [c conn]
             (dotimes [i n]
               (Thread/sleep 500)
               (c/with-txn-retry
@@ -191,7 +191,7 @@
 
   (invoke! [this test op]
     (c/with-exception->op op
-      (rc/with-conn [c conn]
+      (c/with-conn [c conn]
         (c/with-timeout
           (c/with-txn-retry
             (c/with-txn [c c]
@@ -233,7 +233,7 @@
 
   (teardown! [this test]
     (try
-      (rc/with-conn [c conn]
+      (c/with-conn [c conn]
         (c/with-timeout
           (dotimes [i n]
             (j/execute! c [(str "drop table if exists accounts" i)]))))

--- a/cockroachdb/src/jepsen/cockroach/client.clj
+++ b/cockroachdb/src/jepsen/cockroach/client.clj
@@ -240,7 +240,7 @@
   [client]
   (util/timeout 60000 (throw (RuntimeException. "Timed out waiting for conn"))
                 (while (try
-                         (rc/with-conn [c client]
+                         (with-conn [c client]
                            (j/query c ["select 1"])
                            false)
                          (catch RuntimeException e

--- a/cockroachdb/src/jepsen/cockroach/comments.clj
+++ b/cockroachdb/src/jepsen/cockroach/comments.clj
@@ -47,7 +47,7 @@
     (let [client (c/client node)]
       (locking table-created?
         (when (compare-and-set! table-created? false true)
-          (rc/with-conn [c client]
+          (c/with-conn [c client]
             (c/with-timeout
               (info "Creating tables" (pr-str (table-names table-count)))
               (doseq [t (table-names table-count)]
@@ -60,7 +60,7 @@
 
   (invoke! [this test op]
     (c/with-exception->op op
-      (rc/with-conn [c client]
+      (c/with-conn [c client]
         (c/with-timeout
             (case (:f op)
               :write (let [[k id] (:value op)

--- a/cockroachdb/src/jepsen/cockroach/monotonic.clj
+++ b/cockroachdb/src/jepsen/cockroach/monotonic.clj
@@ -95,7 +95,7 @@
 
       (locking table-created?
         (when (compare-and-set! table-created? false true)
-          (rc/with-conn [c conn]
+          (c/with-conn [c conn]
             (doseq [k independent-keys]
               (monotonic-create-tables! c k table-count
                                         (:val-as-pkey? test))))))
@@ -106,7 +106,7 @@
     (let [[k value] (:value op)
           tables    (map table-name (repeat k) (range table-count))]
       (c/with-exception->op op
-        (rc/with-conn [c conn]
+        (c/with-conn [c conn]
           (case (:f op)
             :add (c/with-txn-retry-as-fail op
                    (c/with-timeout

--- a/cockroachdb/src/jepsen/cockroach/nemesis.clj
+++ b/cockroachdb/src/jepsen/cockroach/nemesis.clj
@@ -284,7 +284,7 @@
 
        (invoke! [this test op]
          (assoc op :value
-                (rc/with-conn [c (rand-nth clients)]
+                (cc/with-conn [c (rand-nth clients)]
                   (letr [keyrange  (:keyrange test)
                          keyrange  (if keyrange
                                      @keyrange

--- a/cockroachdb/src/jepsen/cockroach/register.clj
+++ b/cockroachdb/src/jepsen/cockroach/register.clj
@@ -28,7 +28,7 @@
       ;; Everyone's gotta block until we've made the table.
       (locking tbl-created?
         (when (compare-and-set! tbl-created? false true)
-          (rc/with-conn [c conn]
+          (c/with-conn [c conn]
             (Thread/sleep 1000)
             (j/execute! c ["drop table if exists test"])
             (Thread/sleep 1000)

--- a/cockroachdb/src/jepsen/cockroach/sequential.clj
+++ b/cockroachdb/src/jepsen/cockroach/sequential.clj
@@ -56,7 +56,7 @@
     (let [client (c/client node)]
       (locking table-created?
         (when (compare-and-set! table-created? false true)
-          (rc/with-conn [c client]
+          (c/with-conn [c client]
             (c/with-timeout
               (info "Creating tables" (pr-str (table-names table-count)))
               (doseq [t (table-names table-count)]
@@ -69,7 +69,7 @@
 
   (invoke! [this test op]
     (c/with-exception->op op
-      (rc/with-conn [c client]
+      (c/with-conn [c client]
         (c/with-timeout
           (let [ks (subkeys (:key-count test) (:value op))]
             (case (:f op)
@@ -96,7 +96,7 @@
 
   (teardown! [this test]
     (try
-      (rc/with-conn [c client]
+      (c/with-conn [c client]
         (c/with-timeout
           (doseq [t (table-names table-count)]
             (j/execute! c [(str "drop table " t)]))))

--- a/cockroachdb/src/jepsen/cockroach/sets.clj
+++ b/cockroachdb/src/jepsen/cockroach/sets.clj
@@ -102,7 +102,7 @@
 
       (locking tbl-created?
         (when (compare-and-set! tbl-created? false true)
-          (rc/with-conn [c conn]
+          (c/with-conn [c conn]
             (Thread/sleep 1000)
             (j/execute! c ["drop table if exists set"])
             (Thread/sleep 1000)
@@ -113,7 +113,7 @@
 
   (invoke! [this test op]
     (c/with-exception->op op
-      (rc/with-conn [c conn]
+      (c/with-conn [c conn]
         (c/with-txn-retry
           (case (:f op)
             :add (c/with-timeout
@@ -127,7 +127,7 @@
   (teardown! [this test]
     (try
       (c/with-timeout
-        (rc/with-conn [c conn]
+        (c/with-conn [c conn]
           (j/execute! c ["drop table set"])))
       (finally (rc/close! conn)))))
 


### PR DESCRIPTION
The register tests were failing consistently because the concurrency parameter was not set correctly; the first commit fixes that.

The second commit modifies `util/timeout` to improve error reporting (when there was an `InterruptedException`, it was getting clobbered by a `NullPointerException` in `unwrap-exception`).

The third commit fixes a hang that is sometimes seen at shutdown in several tests (always associated with the `InterruptedException` noted above). I haven't quite figured out why this is so, but empirically it seems to work. 

cc @knz 