### PR TITLE
Misc. fixups for cockroachdb tests

### DIFF
--- a/cockroachdb/project.clj
+++ b/cockroachdb/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.3"]
+                 [jepsen "0.1.5"]
                  [org.clojure/java.jdbc "0.6.1"]
                  [circleci/clj-yaml "0.5.5"]
                  [org.postgresql/postgresql "9.4.1211"]]

--- a/cockroachdb/src/jepsen/cockroach/register.clj
+++ b/cockroachdb/src/jepsen/cockroach/register.clj
@@ -99,5 +99,5 @@
                        :details (independent/checker
                                   (checker/compose
                                     {:timeline     (timeline/html)
-                                     :linearizable checker/linearizable}))})}
+                                     :linearizable (checker/linearizable)}))})}
       opts)))

--- a/cockroachdb/src/jepsen/os/ubuntu.clj
+++ b/cockroachdb/src/jepsen/os/ubuntu.clj
@@ -7,7 +7,7 @@
 	    [jepsen.os.debian :as debian]
             [jepsen.control :as c]
             [jepsen.control.util :as cu]
-            [jepsen.control.net :as net]
+            [jepsen.net :as net]
             [clojure.string :as str]))
 
 (def os
@@ -35,6 +35,6 @@
                   :logrotate])
 	(c/su (c/exec :service :ntp :stop)))
 
-      (meh (net/heal)))
+      (meh (net/heal! (:net test) test)))
 
     (teardown! [_ test node])))

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -15,6 +15,7 @@
                  [org.clojars.achim/multiset "0.1.0"]
                  [byte-streams "0.2.2"]]
   :main jepsen.cli
+  :plugins [[lein-localrepo "0.5.4"]]
   :aot [jepsen.cli clojure.tools.logging.impl]
 ;        clojure.tools.logging.impl]
   :jvm-opts ["-Xmx32g" "-XX:+UseConcMarkSweepGC" "-XX:+UseParNewGC"


### PR DESCRIPTION
- Upgrade to Jepsen 1.0.5
- Add parenthesis around linearizable checker in register test to get the actual checker instance rather than the function that returns the instance
- Updated cockroach/os/ubuntu.clj to use jepsen.net and fix-up heal call
- Added lein-localrepo plugin to jepsen library build so it is now possible to install the local snapshot build to local maven repository for testing.