### PR TITLE
Update jepsen to 0.14 and added main method

### DIFF
--- a/crate/project.clj
+++ b/crate/project.clj
@@ -1,5 +1,6 @@
 (defproject jepsen.crate "0.1.0-SNAPSHOT"
   :description "FIXME: write description"
+  :main jepsen.crate
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -15,7 +16,7 @@
              "-XX:MaxRecursiveInlineLevel=2"
              "-server"]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.3-SNAPSHOT"]
+                 [jepsen "0.1.4"]
                  [cheshire "5.6.2"]
                  [org.elasticsearch/elasticsearch "2.3.4"]
                  [io.crate/crate-client "0.55.2"]])

--- a/crate/src/jepsen/crate.clj
+++ b/crate/src/jepsen/crate.clj
@@ -3,6 +3,7 @@
                     [db           :as db]
                     [control      :as c :refer [|]]
                     [checker      :as checker]
+                    [cli          :as cli]
                     [client       :as client]
                     [generator    :as gen]
                     [independent  :as independent]
@@ -347,3 +348,10 @@
                                              {:type :info, :f :stop}])))
                           (gen/time-limit 360))}
          opts))
+
+(defn -main [& args]
+  "Handles command line arguments. Can either run a test, or a web service 
+  browsing results."
+  (cli/run! (merge (cli/single-test-cmd {:test-fn an-test})
+                   (cli/serve-cmd))
+            args))


### PR DESCRIPTION
We can now run the tests with `lein run test --[OPTIONS]`