### PR TITLE
move timeline nemesis values to tooltip

### DIFF
--- a/jepsen/src/jepsen/checker/timeline.clj
+++ b/jepsen/src/jepsen/checker/timeline.clj
@@ -72,11 +72,12 @@
 
                                true
                                (assoc s :height height)))
-           :title (str (when stop (str (long (util/nanos->ms
-                                               (- (:time stop) (:time start))))
+           :title (str (when (and (= :nemesis (:process op)) (:value start)) (str (:value start) "\n"))
+                       (when stop (str (long (util/nanos->ms
+                                              (- (:time stop) (:time start))))
                                        " ms\n"))
                        (pr-str (:error op)))}
-     (str (:process op) " " (name+ (:f op)) " " (:value start)
+     (str (:process op) " " (name+ (:f op)) " " (when (not= :nemesis (:process op)) (:value start))
           (when (not= (:value start) (:value stop))
             (str "<br />" (:value stop))))]))
 


### PR DESCRIPTION
In order to fix:
<img width="776" alt="within cells interlinked1" src="https://user-images.githubusercontent.com/938395/32029849-f53c9dbe-b9ab-11e7-8e99-2d1247279e74.png">

I moved the (:value start) for nemesis processes into their tooltip. I do not believe that this change affects div positioning.

New behavior:
![2017-10-25 17 39 11](https://user-images.githubusercontent.com/938395/32029909-3db47a80-b9ac-11e7-95a8-a47020ecf130.gif)


Within cells interlinked
(fully connected)
Within cells interlinked
(fully connected)
interlinked
(fully connected)
![ndrs4pvuzurz](https://user-images.githubusercontent.com/938395/32029929-5dca4142-b9ac-11e7-8d27-fa335da9afad.png)
