### PR TITLE
Allow for docker-compose to run as daemon as well.

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -25,6 +25,10 @@ for f in $@; do
 	'--init-only' )
 	    INIT_ONLY=1
 	    ;;
+	'--daemon' )
+		INFO "DAEMON"
+	    RUN_AS_DAEMON=1
+	    ;;
 	*)
 	    ERROR "unknown option $1"
 	    exit 1
@@ -66,7 +70,7 @@ INFO "Copying .. to control/jepsen"
 (
     rm -rf ./control/jepsen
     mkdir ./control/jepsen
-    (cd ..; tar --exclude=./docker -cf - .)  | tar Cxf ./control/jepsen -
+    (cd ..; tar --exclude=./docker --exclude=./.git -cf - .)  | tar Cxf ./control/jepsen -
 )
 
 
@@ -81,5 +85,10 @@ INFO "Running \`docker-compose build\`"
 docker-compose build
 
 INFO "Running \`docker-compose up\`"
-INFO "Please run \`docker exec -it jepsen-control bash\` in another terminal to proceed"
-docker-compose up
+if [ "$RUN_AS_DAEMON" ]; then
+	docker-compose up -d
+	exit 0
+else
+	INFO "Please run \`docker exec -it jepsen-control bash\` in another terminal to proceed"
+	docker-compose up
+fi


### PR DESCRIPTION
Spinning up the docker environment using `--daemon` allows for better automation of 
the "spin up containers and kick off tests" scenario.

Also, exclude .git when copying jepsen inside ./docker/control/jepsen as
this avoids the current git repository from hosting itself (on a nested level).
It can be confusing to operate in the git repo under ./docker/control/jepsen/.../ and not see the changes in the proper "root" repository in other terminals or such.