### PR TITLE
Nemesis protocol

### DIFF
--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -28,6 +28,7 @@
             [jepsen.generator :as generator]
             [jepsen.checker :as checker]
             [jepsen.client :as client]
+            [jepsen.nemesis :as nemesis]
             [jepsen.store :as store])
   (:import (java.util.concurrent CyclicBarrier)))
 
@@ -228,7 +229,7 @@
 
               (try
                 (util/log-op op)
-                (let [completion (-> (client/invoke! nemesis test op)
+                (let [completion (-> (nemesis/invoke-compat! nemesis test op)
                                      (assoc :time (relative-time-nanos)))]
                   (util/log-op completion)
 
@@ -257,7 +258,7 @@
   nemesis completion, and tears down nemesis."
   [test & body]
   ; Initialize nemesis
-  `(let [nemesis# (client/setup! (:nemesis ~test) ~test nil)]
+  `(let [nemesis# (nemesis/setup-compat! (:nemesis ~test) ~test nil)]
      (try
        ; Launch nemesis thread
        (let [worker# (nemesis-worker ~test nemesis#)
@@ -269,7 +270,7 @@
          result#)
        (finally
          (info "Tearing down nemesis")
-         (client/teardown! nemesis# ~test)
+         (nemesis/teardown-compat! nemesis# ~test)
          (info "Nemesis torn down")))))
 
 (defn run-case!

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -7,9 +7,9 @@
             [jepsen.net         :as net]))
 
 (defprotocol Nemesis
-  (setup! [this test] "Docstring here")
-  (invoke! [this test op] "Docstring here")
-  (teardown! [this test] "Docstring here"))
+  (setup! [this test] "Set up the nemesis to work with the cluster. Returns the nemesis ready to be invoked")
+  (invoke! [this test op] "Apply an operation to the nemesis, which alters the cluster.")
+  (teardown! [this test] "Tear down the nemesis when work is complete"))
 
 (def noop
   "Does nothing."
@@ -18,9 +18,31 @@
     (invoke! [this test op] op)
     (teardown! [this test] this)))
 
-(defn setup-compat! [nemesis test])
-(defn teardown-compat! [nemesis test])
-(defn invoke-compat! [nemesis test])
+(defn setup-compat!
+  "Calls `jepsen.nemesis/setup!`, if possible, falling back to `jepsen.client/setup!`.
+  Warns users that nemeses implementing `jepsen.client` have been deprecated."
+  [nemesis test node]
+  (if (instance? jepsen.nemesis.Nemesis nemesis)
+    (setup! nemesis test)
+    (do (warn "DEPRECATED: Nemesis does not implement protocol `jepsen.nemesis/Nemesis`, calling `jepsen.client/setup!`. You should migrate to `jepsen.nemesis/Nemesis` to avoid compatibility issues. See the jepsen.nemesis documentation for details.")
+        (client/setup! nemesis test node))))
+
+(defn invoke-compat!
+  "Calls `jepsen.nemesis/invoke!`, if possible, falling back to `jepsen.client/invoke!`."
+  [nemesis test op]
+  (if (instance? jepsen.nemesis.Nemesis nemesis)
+    (invoke! nemesis test op)
+    ;; DEPRECATED
+    (client/invoke! nemesis test op)))
+
+(defn teardown-compat!
+  "Calls `jepsen.nemesis/teardown!`, if possible, falling back to `jepsen.client/teardown!`.
+  Warns users that nemeses implementing `jepsen.client` have been deprecated."
+  [nemesis test]
+  (if (instance? jepsen.nemesis.Nemesis nemesis)
+    (teardown! nemesis test)
+    (do (warn "DEPRECATED: Nemesis does not implement protocol `jepsen.nemesis/Nemesis`, falling back to `jepsen.client/teardown!`. You should migrate to `jepsen.nemesis/Nemesis` to avoid compatibility issues. See the jepsen.nemesis documentation for details.")
+        (client/teardown! nemesis test))))
 
 (defn snub-nodes!
   "Drops all packets from the given nodes."
@@ -78,8 +100,8 @@
   "Responds to a :start operation by cutting network links as defined by
   (grudge nodes), and responds to :stop by healing the network."
   [grudge]
-  (reify client/Client
-    (setup! [this test _]
+  (reify Nemesis
+    (setup! [this test]
       (net/heal! (:net test) test)
       this)
 
@@ -156,9 +178,9 @@
   partition-random-halves."
   [nemeses]
   (assert (map? nemeses))
-  (reify client/Client
-    (setup! [this test node]
-      (compose (util/map-vals #(client/setup! % test node) nemeses)))
+  (reify Nemesis
+    (setup! [this test]
+      (compose (util/map-vals #(setup-compat! % test nil) nemeses)))
 
     (invoke! [this test op]
       (let [f (:f op)]
@@ -168,11 +190,11 @@
                      (str "no nemesis can handle " (:f op))))
             (let [[fs nemesis] (first nemeses)]
               (if-let [f' (fs f)]
-                (assoc (client/invoke! nemesis test (assoc op :f f')) :f f)
+                (assoc (invoke-compat! nemesis test (assoc op :f f')) :f f)
                 (recur (next nemeses))))))))
 
     (teardown! [this test]
-      (util/map-vals #(client/teardown! % test) nemeses))))
+      (util/map-vals #(teardown-compat! % test) nemeses))))
 
 (defn set-time!
   "Set the local node time in POSIX seconds."

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -6,12 +6,21 @@
             [jepsen.control     :as c]
             [jepsen.net         :as net]))
 
+(defprotocol Nemesis
+  (setup! [this test] "Docstring here")
+  (invoke! [this test op] "Docstring here")
+  (teardown! [this test] "Docstring here"))
+
 (def noop
   "Does nothing."
-  (reify client/Client
-    (setup! [this test node] this)
+  (reify Nemesis
+    (setup! [this test] this)
     (invoke! [this test op] op)
     (teardown! [this test] this)))
+
+(defn setup-compat! [nemesis test])
+(defn teardown-compat! [nemesis test])
+(defn invoke-compat! [nemesis test])
 
 (defn snub-nodes!
   "Drops all packets from the given nodes."


### PR DESCRIPTION
The proof of concept was tested with `nemesis/partitioner`, which has been migrated in this branch. I also composed `partitioner` with `hammer-time` to verify that nemeses can be composed across protocols. After some research, I don’t believe any nemeses use the node arg to setup, they all get their node info from test — therefore node can be safely removed. Aside from removing the extra arg, migrating to the new protocol should be a drop-in replacement.

I opted not to warn when invoke is called to avoid spamming up the invocation history. Warning in the `setup!` and `teardown!` phases felt sufficient.

Once both this and the updates to jepsen.client land, I’d like to circle back to `jepsen.core/nemesis-worker` and update `generator/op` with `generator/op-and-validate`