### PR TITLE
Timeline ops can be linked to and now link to themselves

### DIFF
--- a/jepsen/src/jepsen/checker/timeline.clj
+++ b/jepsen/src/jepsen/checker/timeline.clj
@@ -71,19 +71,19 @@
         op (or stop start)
         s {:width  col-width
            :left   (* gutter-width (get process-index p))
-           :top    (* height (:t-index start))}]
+           :top    (* height (:sub-index start))}]
     [:a {:href (str "#i" (:index op))}
      [:div {:class (str "op " (name (:type op)))
             :id (str "i" (:index op))
             :style (style (cond (= :info (:type stop))
                                 (assoc s :height (* height
                                                     (- (inc (count history))
-                                                       (:t-index start))))
+                                                       (:sub-index start))))
 
                                 stop
                                 (assoc s :height (* height
-                                                    (- (:t-index stop)
-                                                       (:t-index start))))
+                                                    (- (:sub-index stop)
+                                                       (:sub-index start))))
 
                                 true
                                 (assoc s :height height)))
@@ -118,12 +118,12 @@
        (reduce (fn [m p] (assoc m p (count m)))
                {})))
 
-(defn t-index
-  "Attaches a :t-index key to each element of the history, identifying its
-  position in the timeline."
+(defn sub-index
+  "Attaches a :sub-index key to each element of this timeline's subhistory,
+  identifying its relative position."
   [history]
   (->> history
-       (mapv (fn [i op] (assoc op :t-index i)) (range))
+       (mapv (fn [i op] (assoc op :sub-index i)) (range))
        vec))
 
 (defn html
@@ -139,7 +139,7 @@
                      [:div {:class "ops"}
                       (->> history
                            history/complete
-                           t-index
+                           sub-index
                            pairs
                            (map (partial pair->div
                                          history

--- a/jepsen/src/jepsen/checker/timeline.clj
+++ b/jepsen/src/jepsen/checker/timeline.clj
@@ -51,6 +51,19 @@
                                 (pairs (dissoc invocations (:process op))
                                        ops))))))))
 
+(defn title [op start stop]
+  (str (when (and (= :nemesis (:process op)) (:value start)) (str (:value start) "\n"))
+       (when stop (str (long (util/nanos->ms
+                              (- (:time stop) (:time start))))
+                       " ms\n"))
+       (pr-str (:error op))))
+
+(defn body
+  [op start stop]
+  (str (:process op) " " (name+ (:f op)) " " (when (not= :nemesis (:process op)) (:value start))
+       (when (not= (:value start) (:value stop))
+         (str "<br />" (:value stop)))))
+
 (defn pair->div
   "Turns a pair of start/stop operations into a div."
   [history process-index [start stop]]
@@ -58,28 +71,43 @@
         op (or stop start)
         s {:width  col-width
            :left   (* gutter-width (get process-index p))
-           :top    (* height (:index start))}]
-    [:div {:class (str "op " (name (:type op)))
-           :style (style (cond (= :info (:type stop))
-                               (assoc s :height (* height
-                                                   (- (inc (count history))
-                                                      (:index start))))
+           :top    (* height (:t-index start))}]
+    [:a {:href (str "#i" (:index op))}
+     [:div {:class (str "op " (name (:type op)))
+            :id (str "i" (:index op))
+            :style (style (cond (= :info (:type stop))
+                                (assoc s :height (* height
+                                                    (- (inc (count history))
+                                                       (:t-index start))))
 
-                               stop
-                               (assoc s :height (* height
-                                                   (- (:index stop)
-                                                      (:index start))))
+                                stop
+                                (assoc s :height (* height
+                                                    (- (:t-index stop)
+                                                       (:t-index start))))
 
-                               true
-                               (assoc s :height height)))
-           :title (str (when (and (= :nemesis (:process op)) (:value start)) (str (:value start) "\n"))
-                       (when stop (str (long (util/nanos->ms
-                                              (- (:time stop) (:time start))))
-                                       " ms\n"))
-                       (pr-str (:error op)))}
-     (str (:process op) " " (name+ (:f op)) " " (when (not= :nemesis (:process op)) (:value start))
-          (when (not= (:value start) (:value stop))
-            (str "<br />" (:value stop))))]))
+                                true
+                                (assoc s :height height)))
+            :title (title op start stop)}
+      (body op start stop)]]))
+
+(defn linkify-time
+  "Remove - and : chars from a time string"
+  [t]
+  (clojure.string/replace t #"-|:" ""))
+
+(defn breadcrumbs
+  "Renders a series of back links increasing in depth"
+  [test history-key]
+  (let [files-name (str "/files/" (:name test))
+        start-time (linkify-time (str (:start-time test)))
+        indep      "independent"
+        key        (str history-key)]
+    [:div
+     [:a {:href "/"} "jepsen"] " / "
+     [:a {:href files-name} (str (:name test))] " / "
+     [:a {:href (str files-name "/" start-time)} start-time] " / "
+     [:a {:href (str files-name "/" start-time "/" )} indep] " / "
+     [:a {:href (str files-name "/" start-time "/" indep "/" key)} key]]))
 
 (defn process-index
   "Maps processes to columns"
@@ -90,6 +118,14 @@
        (reduce (fn [m p] (assoc m p (count m)))
                {})))
 
+(defn t-index
+  "Attaches a :t-index key to each element of the history, identifying its
+  position in the timeline."
+  [history]
+  (->> history
+       (mapv (fn [i op] (assoc op :t-index i)) (range))
+       vec))
+
 (defn html
   []
   (reify checker/Checker
@@ -98,12 +134,12 @@
                     [:head
                      [:style stylesheet]]
                     [:body
-                     [:h1 (:name test)]
-                     [:p  (str (:start-time test))]
+                     (breadcrumbs test (:history-key opts))
+                     [:h1 (str (:name test) " key " (:history-key opts))]
                      [:div {:class "ops"}
                       (->> history
                            history/complete
-                           history/index
+                           t-index
                            pairs
                            (map (partial pair->div
                                          history

--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -18,6 +18,7 @@
             [clojure.string :as str]
             [clojure.pprint :refer [pprint]]
             [knossos.core :as knossos]
+            [knossos.history :as history]
             [jepsen.util :as util :refer [with-thread-name
                                           fcatch
                                           real-pmap
@@ -476,6 +477,8 @@
                                    (when (:name test) (store/save-1! test))
                                    test))))))))
               _    (info "Analyzing")
+              ; Give each op in the history a monotonically increasing index
+              test (assoc test :history (history/index (:history test)))
               test (assoc test :results (checker/check-safe
                                           (:checker test)
                                           test

--- a/jepsen/src/jepsen/independent.clj
+++ b/jepsen/src/jepsen/independent.clj
@@ -269,7 +269,8 @@
                                                       [dir k])
                                        results (check-safe
                                                  checker test model h
-                                                 {:subdirectory subdir})]
+                                                 {:subdirectory subdir
+                                                  :history-key  k})]
                                    ; Write analysis
                                    (store/with-out-file test [subdir
                                                               "results.edn"]


### PR DESCRIPTION
Adds monotonically increasing ids to all ops in the history, and adds the current independent subhistory's history-key to each checker's opts. Also adds breadcrumbs to the timeline

New behavior works like:
![2017-11-10 18 36 59](https://user-images.githubusercontent.com/938395/32685445-41a955b0-c646-11e7-8a89-dd4958134fd6.gif)
