### PR TITLE
cockroachdb: Fix build by depending on jepsen 0.1.6

### DIFF
--- a/cockroachdb/project.clj
+++ b/cockroachdb/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.5"]
+                 [jepsen "0.1.6"]
                  [org.clojure/java.jdbc "0.6.1"]
                  [circleci/clj-yaml "0.5.5"]
                  [org.postgresql/postgresql "9.4.1211"]]


### PR DESCRIPTION
PR #181 changed the cockroachdb code to use the new "checkers are defns instead of defs" syntax, which was not available at that time in a stable release (it would go on to be released in jepsen 0.1.6), so `cockroachdb/project.clj` incorrectly declared a dependency on jepsen 0.1.5. This happened to work because of the `cockroachdb/checkouts` directory which caused the `project.clj` version to be ignored. This directory was removed in #183 which crossed in flight with #181. The cockroachdb subproject has been broken in the master branch ever since those two PRs were both merged. This led to an extremely confusing debugging session when we finally got around to upgrading our jepsen branch. 