### PR TITLE
cli: Make tarball-opt backwards-compatible

### DIFF
--- a/jepsen/src/jepsen/cli.clj
+++ b/jepsen/src/jepsen/cli.clj
@@ -96,7 +96,9 @@
     :validate [(partial re-find #"^(file|https?)://.*\.(tar|tgz|zip)")
                "Must be a file://, http://, or https:// URL including .tar, .tgz, or .zip"]]))
 
-(def tarball-opt package-opt)
+(defn tarball-opt
+  [default]
+  (package-opt "tarball" default))
 
 (defn test-usage
   []


### PR DESCRIPTION
The move to jepsen 0.1.6 broke our scripts that used the `--tarball` option; this looks like what was intended (and the other users of `tarball-opt` are also on jepsen 0.1.5). 