### PR TITLE
Control improvements

### DIFF
--- a/jepsen/src/jepsen/control.clj
+++ b/jepsen/src/jepsen/control.clj
@@ -203,8 +203,8 @@
   (with-retry [tries *retries*]
     (rc/with-conn [s *session*]
       (let [local-paths (if (sequential? local-paths)
-                          (map ensure-path local-paths)
-                          (ensure-path local-paths))]
+                          (map file->path local-paths)
+                          (file->path local-paths))]
         (apply ssh/scp-to s local-paths remote-path remaining)
         remote-path))
     (catch com.jcraft.jsch.JSchException e

--- a/jepsen/src/jepsen/control.clj
+++ b/jepsen/src/jepsen/control.clj
@@ -10,7 +10,7 @@
             [jepsen.reconnect :as rc]
             [clojure.string :as str]
             [clojure.pprint :refer [pprint]]
-            [clojure.tools.logging :refer [warn info debug]]))
+            [clojure.tools.logging :refer [warn info debug error]]))
 
 ; STATE STATE STATE STATE
 (def ^:dynamic *dummy*    "When true, don't actually use SSH" nil)
@@ -318,9 +318,9 @@
                                              *strict-host-key-checking*)]
      (try
        ~@body
-       (catch com.jcraft.jsch.JSchException e
-         (error "SSH error, configuration is:\n\n" (util/pprint-str (debug-data))))
-         (throw e))))
+       (catch com.jcraft.jsch.JSchException e#
+         (error "SSH error, configuration is:\n\n" (util/pprint-str (debug-data)))
+         (throw e#)))))
 
 (defmacro with-session
   "Binds a host and session and evaluates body. Does not open or close session;

--- a/jepsen/src/jepsen/control.clj
+++ b/jepsen/src/jepsen/control.clj
@@ -286,7 +286,8 @@
   (rc/close! session))
 
 (defmacro with-ssh
-  "Takes a map of SSH configuration and evaluates body in that scope. Options:
+  "Takes a map of SSH configuration and evaluates body in that scope. Catches
+  JSchExceptions and re-throws with all available debugging context. Options:
 
   :dummy?
   :username
@@ -301,7 +302,11 @@
              *private-key-path* (get ~ssh :private-key-path *private-key-path*)
              *strict-host-key-checking* (get ~ssh :strict-host-key-checking
                                              *strict-host-key-checking*)]
-     ~@body))
+     (try
+       ~@body
+       (catch com.jcraft.jsch.JSchException e
+         (error "SSH error, configuration is:\n\n" (util/pprint-str (debug-data))))
+         (throw e))))
 
 (defmacro with-session
   "Binds a host and session and evaluates body. Does not open or close session;

--- a/jepsen/src/jepsen/control.clj
+++ b/jepsen/src/jepsen/control.clj
@@ -115,7 +115,7 @@
 (defn wrap-trace
   "Logs argument to console when tracing is enabled."
   [arg]
-  (do (when *trace* (info arg))
+  (do (when *trace* (info "Host:" *host* "arg:" arg))
       arg))
 
 (defn throw-on-nonzero-exit


### PR DESCRIPTION
Various items off of plan.md

- Add host to with-trace output
- jepsen.control/upload can now take local java.io.Files and returns the remote-path when finished
- Log additional debugging context when jepsen.control/session fails, incl. hostname, port, username, and password per node.


New behavior in control/session 
When an SSH connection fails, we print context once per node and finally throw the first exception returned from `with-resources`'s `real-pmap`

Here we provide an invalid username, password, and hostname (3 context prints are above the fold here)
<img width="1163" alt="screen shot 2017-11-20 at 2 48 15 pm" src="https://user-images.githubusercontent.com/938395/33046765-575efd6a-ce07-11e7-99b6-14aaed1c076a.png">
