### PR TITLE
fix deprecated `install-tarball!` call in etcd test

### DIFF
--- a/etcd/src/jepsen/etcd.clj
+++ b/etcd/src/jepsen/etcd.clj
@@ -57,7 +57,7 @@
         (info node "installing etcd" version)
         (let [url (str "https://storage.googleapis.com/etcd/" version
                        "/etcd-" version "-linux-amd64.tar.gz")]
-          (cu/install-tarball! c/*host* url dir))
+          (cu/install-archive! url dir))
 
         (cu/start-daemon!
           {:logfile logfile


### PR DESCRIPTION
very smol change