### PR TITLE
fix jepsen.core/invoke-op! and jepsen.core/nemesis-invoke-op!

### DIFF
--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -249,7 +249,7 @@
   "Applies an operation to a client, catching client exceptions and converting
   them to infos. Returns a completion op, throwing if the completion is
   invalid."
-  [op client abort?]
+  [op test client abort?]
   (let [completion (try (-> (client/invoke! client test op)
                             (assoc :time (relative-time-nanos)))
                         (catch Throwable e
@@ -284,7 +284,7 @@
   "Applies an operation to a nemesis, catching exceptions and converting
   them to infos. Returns a completion op, throwing if the completion is
   invalid."
-  [op client abort?]
+  [op test client abort?]
   (let [completion (try (-> (nemesis/invoke-compat! client test op)
                             (assoc :time (relative-time-nanos)))
                         (catch Throwable e
@@ -318,7 +318,7 @@
   [op test client abort?]
   (util/log-op op)
   (conj-op! test op)
-  (let [completion (invoke-op! op client abort?)]
+  (let [completion (invoke-op! op test client abort?)]
     (conj-op! test completion)
     (util/log-op completion)
     completion))
@@ -331,7 +331,7 @@
     (util/log-op op)
     (doseq [history @histories]
       (swap! history conj op))
-    (let [completion (nemesis-invoke-op! op nemesis abort?)]
+    (let [completion (nemesis-invoke-op! op test nemesis abort?)]
       (doseq [history @histories]
         (swap! history conj op))
       (util/log-op completion)


### PR DESCRIPTION
Ran into this while writing a new suite. The new invoke-op! and nemesis-invoke-op! fns fail to pass `test` through which resulted in NullPointerExceptions on nemesis invokes. ClientWorkers weren't affected in the new suite or etcd, but I passed it through to make sure.  `clojure.core/test` was covering this up for compilation, making `test` a valid symbol. I exercised this change in etcd and resolves the exception on nemesis invokes.

Example of bugged behavior:
```
WARN [2017-11-21 23:47:34,849] jepsen nemesis - jepsen.core Process :nemesis crashed
java.lang.IllegalArgumentException: No implementation of method: :heal! of protocol: #'jepsen.net/Net found for class: nil
	at clojure.core$_cache_protocol_fn.invokeStatic(core_deftype.clj:568) ~[clojure-1.8.0.jar:na]
	at clojure.core$_cache_protocol_fn.invoke(core_deftype.clj:560) ~[clojure-1.8.0.jar:na]
	at jepsen.net$fn__4273$G__4219__4280.invoke(net.clj:9) ~[classes/:na]
	at jepsen.nemesis$partitioner$reify__479.invoke_BANG_(nemesis.clj:113) ~[classes/:na]
	at jepsen.nemesis$invoke_compat_BANG_.invokeStatic(nemesis.clj:34) ~[classes/:na]
	at jepsen.nemesis$invoke_compat_BANG_.invoke(nemesis.clj:30) ~[classes/:na]
	at jepsen.core$nemesis_invoke_op_BANG_$fn__700.invoke(core.clj:288) ~[classes/:na]
	at jepsen.core$nemesis_invoke_op_BANG_.invokeStatic(core.clj:288) [classes/:na]
	at jepsen.core$nemesis_invoke_op_BANG_.invoke(core.clj:283) [classes/:na]
	at jepsen.core$nemesis_apply_op_BANG_.invokeStatic(core.clj:334) [classes/:na]
	at jepsen.core$nemesis_apply_op_BANG_.invoke(core.clj:326) [classes/:na]
	at jepsen.core.NemesisWorker.run_worker_BANG_(core.clj:420) [classes/:na]
	at jepsen.core$do_worker_BANG_.invokeStatic(core.clj:168) [classes/:na]
	at jepsen.core$do_worker_BANG_.invoke(core.clj:155) [classes/:na]
	at jepsen.core$run_workers_BANG_$fn__679$fn__680.invoke(core.clj:221) [classes/:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) [clojure-1.8.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) [clojure-1.8.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:646) [clojure-1.8.0.jar:na]
	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1881) [clojure-1.8.0.jar:na]
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1881) [clojure-1.8.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:425) [clojure-1.8.0.jar:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:156) [clojure-1.8.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:132) [clojure-1.8.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:650) [clojure-1.8.0.jar:na]
	at clojure.core$bound_fn_STAR_$fn__4671.doInvoke(core.clj:1911) [clojure-1.8.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) [clojure-1.8.0.jar:na]
	at clojure.lang.AFn.run(AFn.java:22) [clojure-1.8.0.jar:na]
	at java.lang.Thread.run(Thread.java:748) [na:1.8.0_151]
```

Example of fixed behavior:
```
Analysis invalid! (ﾉಥ益ಥ）ﾉ ┻━┻
```

Example of a puppy
```
(V●ᴥ●V)
```