### PR TITLE
Avoid "availableProcessors is already set" exception.

### DIFF
--- a/crate/project.clj
+++ b/crate/project.clj
@@ -14,6 +14,7 @@
              "-XX:-OmitStackTraceInFastThrow"
              "-XX:MaxInlineLevel=32"
              "-XX:MaxRecursiveInlineLevel=2"
+             "-Des.set.netty.runtime.available.processors=false"
              "-server"]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [jepsen "0.1.5"]


### PR DESCRIPTION
Ensures that the ES client does not try to set the number of processors
when the client initializes. It could be already set at inside the same
JVM which raises an exception.
Although this setting is just an upper limit to prevent too many threads
on machines with many cores (>32), this is not relevant for our tests
here.

https://github.com/netty/netty/issues/6956