### PR TITLE
charybdefs: Introduce a nemesis, use it in cockroachdb

### DIFF
--- a/cockroachdb/checkouts/charybdefs
+++ b/cockroachdb/checkouts/charybdefs
@@ -1,0 +1,1 @@
+../../charybdefs

--- a/cockroachdb/src/jepsen/cockroach.clj
+++ b/cockroachdb/src/jepsen/cockroach.clj
@@ -31,6 +31,7 @@
                                                      db-user
                                                      db-passwd
                                                      store-path
+                                                     cleanup-path
                                                      dbname
                                                      verlog
                                                      log-files
@@ -103,11 +104,11 @@
         (c/su
           (auto/kill! test node)
 
-          (info node "Erasing the store...")
-          (c/exec :rm :-rf store-path)
-
           (info node "Stopping tcpdump...")
           (meh (c/exec :killall -9 :tcpdump))
+
+          (info node "Erasing the store...")
+          (c/exec :rm :-rf cleanup-path)
 
           (info node "Clearing the logs...")
           (doseq [f log-files]

--- a/cockroachdb/src/jepsen/cockroach/auto.clj
+++ b/cockroachdb/src/jepsen/cockroach/auto.clj
@@ -32,10 +32,18 @@
 ;; Paths
 (def working-path "Home directory for cockroach setup" "/opt/cockroach")
 (def cockroach "Cockroach binary" (str working-path "/cockroach"))
-(def store-path "Cockroach data dir" (str working-path "/cockroach-data"))
 (def pidfile "Cockroach PID file" (str working-path "/pid"))
 
-; Logs
+;; Hard-coded paths for use with the disk nemesis. When the disk
+;; nemesis is not used, we may want to use a normal path, but
+;; using the CharybdeFS filesystem all the time appears to work,
+;; with one exception: rm -rf /faulty/cockroach-data fails
+;; mysteriously. I'm not sure what's going on, but running
+;; the cleanup on /real instead of /faulty works around it.
+(def store-path "Cockroach data dir" "/faulty/cockroach-data")
+(def cleanup-path "Path to clean up after test" "/real/cockroach-data")
+
+                                        ; Logs
 (def log-path "Log directory" (str working-path "/logs"))
 (def verlog "Version log file" (str log-path "/version.txt"))
 (def pcaplog "pcap log file" (str log-path "/trace.pcap"))
@@ -49,6 +57,7 @@
 ;; Extra command-line arguments to give to `cockroach start`
 (def cockroach-start-arguments
   (concat [:start
+           :--store store-path
            ;; ... other arguments here ...
            ]
           (if insecure [:--insecure] [])))

--- a/cockroachdb/src/jepsen/cockroach/nemesis.clj
+++ b/cockroachdb/src/jepsen/cockroach/nemesis.clj
@@ -8,6 +8,7 @@
              [generator :as gen]
              [reconnect :as rc]
              [util :as util :refer [letr]]]
+            [jepsen.charybdefs :as charybdefs]
             [jepsen.nemesis.time :as nt]
             [jepsen.cockroach.client :as cc]
             [jepsen.cockroach.auto :as auto]
@@ -315,3 +316,13 @@
    :name   "splits"
    :client (split-nemesis)
    :clocks false})
+
+;; Periodic disk failures
+(defn disk
+  []
+  (merge (nemesis-single-gen)
+         {:name "disk"
+          ;; The cockroach process usually reacts to disk failures by dying,
+          ;; so restart it after the nemesis restores the disk.
+          :client (restarting (charybdefs/nemesis))
+          :clocks false}))

--- a/cockroachdb/src/jepsen/cockroach/runner.clj
+++ b/cockroachdb/src/jepsen/cockroach/runner.clj
@@ -84,7 +84,7 @@
     :parse-fn #(Long/parseLong %)
     :validate [pos? "Must be positive"]]
 
-   (jc/tarball-opt "https://binaries.cockroachdb.com/cockroach-beta-20170330.linux-amd64.tgz")])
+   (jc/package-opt "tarball" "https://binaries.cockroachdb.com/cockroach-beta-20170330.linux-amd64.tgz")])
 
 (defn log-test
   [t]

--- a/cockroachdb/src/jepsen/cockroach/runner.clj
+++ b/cockroachdb/src/jepsen/cockroach/runner.clj
@@ -7,11 +7,13 @@
             [clojure.string :as str]
             [clojure.java.io :as io]
             [jepsen.cli :as jc]
+            [jepsen.control :as c]
             [jepsen.os :as os]
             [jepsen.os.debian :as debian]
             [jepsen.os.ubuntu :as ubuntu]
             [jepsen.core :as jepsen]
             [jepsen.web :as web]
+            [jepsen.charybdefs :as charybdefs]
             [jepsen.cockroach :as cockroach]
             [jepsen.cockroach [adya :as adya]
                               [bank :as bank]
@@ -54,7 +56,8 @@
 ;   "start-stop"                 `(cln/startstop 1)
    "start-stop-2"               `(cln/startstop 2)
 ;   "start-kill"                 `(cln/startkill 1)
-   "start-kill-2"               `(cln/startkill 2)})
+   "start-kill-2"               `(cln/startkill 2)
+   "disk"                       `(cln/disk)})
 
 (def opt-spec
   "Command line options for tools.cli"
@@ -122,6 +125,9 @@
            :usage (jc/test-usage)
            :run (fn [{:keys [options]}]
                   (pprint options)
+                  (c/with-ssh (:ssh options)
+                    (c/on-many (:nodes options)
+                      (charybdefs/install!)))
                   (doseq [i        (range (:test-count options))
                           test-fn  (:test-fns options)
                           [n1 n2]  (nemesis-product (:nemeses options)


### PR DESCRIPTION
Aside from a really weird problem with `rm -rf`, this seems to be working. It's mostly equivalent to the `kill` nemesis for cockroach since IO errors (mostly) cause the process to panic. Don't do a release with this yet - I'm going to rename `charybdefs/nemesis` to introduce a handful of different nemeses (like one that lets reads work but returns ENOSPC for any write). 