### PR TITLE
Add support for running Jepsen without using SSH

### DIFF
--- a/jepsen/src/jepsen/db.clj
+++ b/jepsen/src/jepsen/db.clj
@@ -11,6 +11,9 @@
 (defprotocol LogFiles
   (log-files [db test node] "Returns a sequence of log files for this node."))
 
+(defprotocol LogSnarfer
+  (snarf-logs! [db test] "Downloads logs for a test."))
+
 (def noop
   "Does nothing."
   (reify DB


### PR DESCRIPTION
This enables tests which have the means to run without any OS-level virtualization to avoid attempting to establish SSH connections on start-up.

----

@aphyr, my changes from jepsen-io/mongodb#9 depend on these changes to the jepsen-io/jepsen repository.