### PR TITLE
Add punctuation to web's test times

### DIFF
--- a/etcd/project.clj
+++ b/etcd/project.clj
@@ -5,5 +5,5 @@
   :main jepsen.etcd
   :jvm-opts ["-Dcom.sun.management.jmxremote"]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.8"]
+                 [jepsen "0.1.9-SNAPSHOT"]
                  [verschlimmbesserung "0.1.3"]])

--- a/jepsen/src/jepsen/web.clj
+++ b/jepsen/src/jepsen/web.clj
@@ -6,6 +6,7 @@
             [clojure.java.io :as io]
             [clojure.tools.logging :refer :all]
             [clojure.pprint :refer [pprint]]
+            [clj-time.format :as timef]
             [hiccup.core :as h]
             [ring.util.response :as response]
             [org.httpkit.server :as server])
@@ -102,10 +103,14 @@
 (defn test-row
   "Turns a test map into a table row."
   [t]
-  (let [r (:results t)]
+  (let [r    (:results t)
+        time (->> t
+                  :start-time
+                  (timef/parse   (timef/formatters :basic-date-time))
+                  (timef/unparse (timef/formatters :date-hour-minute-second)))]
     [:tr
      [:td [:a {:href (url t "")} (:name t)]]
-     [:td [:a {:href (url t "")} (:start-time t)]]
+     [:td [:a {:href (url t "")} time]]
      [:td {:style (str "background: " (valid-color (:valid? r)))}
       (:valid? r)]
      [:td [:a {:href (url t "results.edn")}    "results.edn"]]


### PR DESCRIPTION
Tiny change cause I can't read un-punctuated ISO 8601 dates worth a heck. Also trims the millis at the end which were zeroed out due to `jepsen.util/local-time` so it actually takes up less space!

Before:
<img width="520" alt="screen shot 2018-03-21 at 1 24 43 pm" src="https://user-images.githubusercontent.com/938395/37735796-5712b8ec-2d0c-11e8-922c-f32280fe75ff.png">

After:
<img width="563" alt="add punct to web s test times" src="https://user-images.githubusercontent.com/938395/37735809-5f35949a-2d0c-11e8-8057-fe70afb29b1b.png">

Tested with etcd