### PR TITLE
Add missing checker dependency in tutorial

### DIFF
--- a/doc/tutorial/08-set.md
+++ b/doc/tutorial/08-set.md
@@ -60,8 +60,10 @@ Slingshot too.
 
 ```clj
 (ns jepsen.etcdemo.set
-  (:require [jepsen [client :as client]
-            [generator :as gen]]
+  (:require [jepsen
+              [checker :as checker]
+              [client :as client]
+              [generator :as gen]]
             [slingshot.slingshot :refer [try+]]
             [verschlimmbesserung.core :as v]))
 ```


### PR DESCRIPTION
Fixes:
```
$ lein run test --nodes-file ../nodes --username admin --time-limit 10 --concurrency 10 -r 1/2
Exception in thread "main" java.lang.RuntimeException: No such namespace: checker, compiling:(jepsen/etcdemo/set.clj:45:13)
    [...]
Caused by: java.lang.RuntimeException: No such namespace: checker
    [...]
```