### PR TITLE
Tutorial: Fix type of code snippet

### DIFF
--- a/doc/tutorial/03-client.md
+++ b/doc/tutorial/03-client.md
@@ -85,7 +85,7 @@ construct a new Client, and pass `nil` as the value for `conn`. Remember, our
 initial seed client doesn't have a connection; Jepsen will call `open!` to get
 connected clients later.
 
-```
+```clj
 (defn etcd-test
   "Given an options map from the command-line runner (e.g. :nodes, :ssh,
   :concurrency, ...), constructs a test map."


### PR DESCRIPTION
The third code snippet in `doc/tutorial/03-client.md` is not correctly
highlighted as Clojure code as are the other ones. Fix that.