### PR TITLE
Tutorial: Remove superfluous parenthesis in Clojure snippet

### DIFF
--- a/doc/tutorial/03-client.md
+++ b/doc/tutorial/03-client.md
@@ -204,7 +204,7 @@ key. We can pick any name we like--let's call it "foo" for now.
 ```clj
     (invoke! [this test op]
       (case (:f op)
-        :read (assoc op :type :ok, :value (v/get conn "foo")))))
+        :read (assoc op :type :ok, :value (v/get conn "foo"))))
 ```
 
 We dispatch based on the `:f` field of the operation, and when it's a


### PR DESCRIPTION
It appears there is a superfluous parenthesis in one of the snippets
around the `invoke!` function. This change removes it.