### PR TITLE
Drop obsolete plugin, update crate tests to jepsen 0.1.8 and fix lost-updates test.

### DIFF
--- a/crate/project.clj
+++ b/crate/project.clj
@@ -17,7 +17,7 @@
              "-Des.set.netty.runtime.available.processors=false"
              "-server"]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.5"]
+                 [jepsen "0.1.8"]
                  [cheshire "5.6.2"]
                  [org.clojure/java.jdbc "0.7.2"]
                  [clj-http "3.1.0"]

--- a/crate/resources/crate.in.sh
+++ b/crate/resources/crate.in.sh
@@ -11,7 +11,7 @@ EOF
     exit 1
 fi
 
-CRATE_CLASSPATH=$CRATE_HOME/lib/*:$CRATE_HOME/lib/enterprise/*:$CRATE_HOME/lib/sigar/*
+CRATE_CLASSPATH=$CRATE_HOME/lib/*:$CRATE_HOME/lib/enterprise/*
 
 if [ "x$CRATE_MIN_MEM" = "x" ]; then
     CRATE_MIN_MEM=256m

--- a/crate/src/jepsen/crate/core.clj
+++ b/crate/src/jepsen/crate/core.clj
@@ -282,7 +282,7 @@
     (debian/install [:apt-transport-https])
     (install-open-jdk8!)
     (cu/ensure-user! user)
-    (cu/install-tarball! node tarball-url base-dir false)
+    (cu/install-archive! tarball-url base-dir false)
     (c/exec :chown :-R (str user ":" user) base-dir))
   (info node "crate installed"))
 

--- a/crate/src/jepsen/crate/lost_updates.clj
+++ b/crate/src/jepsen/crate/lost_updates.clj
@@ -45,8 +45,8 @@
             (info node "Creating table sets")
             (j/execute! c
                         ["create table if not exists sets (
-                         id     integer primary key,
-                         elements string)"])
+                         id       integer primary key,
+                         elements string INDEX OFF STORAGE WITH (columnstore = false))"])
             (j/execute! c
                         ["alter table sets
                          set (number_of_replicas = \"0-all\")"]))))

--- a/crate/src/jepsen/crate/lost_updates.clj
+++ b/crate/src/jepsen/crate/lost_updates.clj
@@ -32,7 +32,9 @@
 (defrecord LostUpdatesClient [tbl-created? conn]
   client/Client
 
-  (setup! [this test node]
+  (setup! [this test])
+
+  (open! [this test node]
     (let [conn (c/jdbc-client node)]
       (info node "Connected")
       ;; Everyone's gotta block until we've made the table.
@@ -94,6 +96,8 @@
                                           k els']
                                        {:timeout c/timeout-delay})
                            (assoc op :type :ok)))))))))))
+
+  (close! [this test])
 
   (teardown! [this test]
     ))

--- a/crate/src/jepsen/crate/version_divergence.clj
+++ b/crate/src/jepsen/crate/version_divergence.clj
@@ -29,7 +29,9 @@
 (defrecord VersionDivergenceClient [tbl-created? conn]
   client/Client
 
-  (setup! [this test node]
+  (setup! [this test])
+
+  (open! [this test node]
     (let [conn (c/jdbc-client node)]
       (info node "Connected")
       ;; Everyone's gotta block until we've made the table.
@@ -83,6 +85,8 @@
 
                 :else
                 (throw e))))))))
+
+  (close! [this test])
 
   (teardown! [this test]
     (rc/close! conn)))


### PR DESCRIPTION
A few minor changes to continue being able to run the tests with the latest CrateDB release (2.3). 

We do not use the sigar plugin anymore so drop that from the crate classpath. 
We update the test suite to use the latest jepsen (0.1.8). 
Fix the lost-updates test to be able to insert the generated `elements` values in the `sets` table 
(to mitigate Lucene's max term length of 32766 bytes).