### PR TITLE
Add gcc to the lists of dependencies for Centos

### DIFF
--- a/jepsen/src/jepsen/os/centos.clj
+++ b/jepsen/src/jepsen/os/centos.clj
@@ -142,6 +142,7 @@
       (c/su
         ; Packages!
         (install [:wget
+                  :gcc
                   :curl
                   :vim-common
                   :unzip


### PR DESCRIPTION
#270 I found the error message was `configure: error: no acceptable C compiler found in $PATH`, So I think that need to add `GCC` to the lists of dependencies and will be solved.