### PR TITLE
#270: Added gcc-c++ for CentOS

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.1.9"
+(defproject jepsen "0.1.10-SNAPSHOT"
   :description "Call Me Maybe: Network Partitions in Practice"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/data.fressian "0.2.1"]

--- a/jepsen/src/jepsen/os/centos.clj
+++ b/jepsen/src/jepsen/os/centos.clj
@@ -1,5 +1,5 @@
 (ns jepsen.os.centos
-  "Common tasks for CentOS boxex."
+  "Common tasks for CentOS boxes."
   (:use clojure.tools.logging)
   (:require [clojure.set :as set]
             [jepsen.util :refer [meh]]
@@ -143,6 +143,7 @@
         ; Packages!
         (install [:wget
                   :gcc
+                  :gcc-c++
                   :curl
                   :vim-common
                   :unzip


### PR DESCRIPTION
Fix for the https://github.com/jepsen-io/jepsen/issues/270. 
@aphyr , @Leviathan1995 , should the version be bumped to "0.1.10-SNAPSHOT", since "0.1.9" has been already released? 