### PR TITLE
#271: Overridden build essentials installation for CentOS

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.1.9"
+(defproject jepsen "0.1.10-SNAPSHOT"
   :description "Call Me Maybe: Network Partitions in Practice"
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/data.fressian "0.2.1"]

--- a/jepsen/src/jepsen/nemesis/time.clj
+++ b/jepsen/src/jepsen/nemesis/time.clj
@@ -46,7 +46,7 @@
     (debian/install [:build-essential])
     (compile-tools!)))
   ([opts]
-   (os/install-build-essential! (:os opts))
+   (os/install-build-dependencies! (:os opts))
    (compile-tools!)))
 
 (defn reset-time!

--- a/jepsen/src/jepsen/nemesis/time.clj
+++ b/jepsen/src/jepsen/nemesis/time.clj
@@ -5,7 +5,8 @@
                     [client :as client]
                     [control :as c]
                     [generator :as gen]
-                    [nemesis :as nemesis]]
+                    [nemesis :as nemesis]
+                    [os :as os]]
             [clojure.java.io :as io])
   (:import (java.io File)))
 
@@ -33,14 +34,20 @@
   (with-open [r (io/reader (io/resource resource))]
     (compile! r bin)))
 
+(defn compile-tools!
+  []
+  (compile-resource! "strobe-time.c" "strobe-time")
+  (compile-resource! "bump-time.c" "bump-time"))
+
 (defn install!
   "Uploads and compiles some C programs for messing with clocks."
-  []
+  ([]
   (c/su
     (debian/install [:build-essential])
-
-    (compile-resource! "strobe-time.c" "strobe-time")
-    (compile-resource! "bump-time.c" "bump-time")))
+    (compile-tools!)))
+  ([opts]
+   (os/install-build-essential! (:os opts))
+   (compile-tools!)))
 
 (defn reset-time!
   "Resets the local node's clock to NTP. If a test is given, resets time on all
@@ -71,7 +78,7 @@
   []
   (reify nemesis/Nemesis
     (setup! [nem test]
-      (c/with-test-nodes test (install!))
+      (c/with-test-nodes test (install! test))
       (reset-time! test)
       nem)
 

--- a/jepsen/src/jepsen/os.clj
+++ b/jepsen/src/jepsen/os.clj
@@ -5,10 +5,12 @@
   (setup!     [os test node] "Set up the operating system on this particular
                              node.")
   (teardown!  [os test node] "Tear down the operating system on this particular
-                             node."))
+                             node.")
+  (install-build-essential! [os] "Install build tools."))
 
 (def noop
   "Does nothing"
   (reify OS
     (setup!    [os test node])
-    (teardown! [os test node])))
+         (teardown! [os test node])
+         (install-build-essential! [os])))

--- a/jepsen/src/jepsen/os.clj
+++ b/jepsen/src/jepsen/os.clj
@@ -6,11 +6,11 @@
                              node.")
   (teardown!  [os test node] "Tear down the operating system on this particular
                              node.")
-  (install-build-essential! [os] "Install build tools."))
+  (install-build-dependencies! [os] "Install build tools."))
 
 (def noop
   "Does nothing"
   (reify OS
     (setup!    [os test node])
          (teardown! [os test node])
-         (install-build-essential! [os])))
+         (install-build-dependencies! [os])))

--- a/jepsen/src/jepsen/os/centos.clj
+++ b/jepsen/src/jepsen/os/centos.clj
@@ -1,5 +1,5 @@
 (ns jepsen.os.centos
-  "Common tasks for CentOS boxex."
+  "Common tasks for CentOS boxes."
   (:use clojure.tools.logging)
   (:require [clojure.set :as set]
             [jepsen.util :refer [meh]]
@@ -154,6 +154,13 @@
 
       (if (not= true (installed-start-stop-daemon?)) (install-start-stop-daemon!) (info "start-stop-daemon already installed"))
 
+      (c/su (c/exec :systemctl :stop :ntpd))
+
       (meh (net/heal! (:net test) test)))
 
-    (teardown! [_ test node])))
+    (teardown! [_ test node]
+      (info node "tearing down centos")
+      (c/su (c/exec :systemctl :start :ntpd)))
+
+    (install-build-essential! [_]
+      (install [:gcc :gcc-c++ :make :openssl-devel]))))

--- a/jepsen/src/jepsen/os/centos.clj
+++ b/jepsen/src/jepsen/os/centos.clj
@@ -162,5 +162,5 @@
       (info node "tearing down centos")
       (c/su (c/exec :systemctl :start :ntpd)))
 
-    (install-build-essential! [_]
+    (install-build-dependencies! [_]
       (install [:gcc :gcc-c++ :make :openssl-devel]))))

--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -166,5 +166,5 @@
 
     (teardown! [_ test node])
 
-    (install-build-essential! [_]
+    (install-build-dependencies! [_]
       (install [:build-essential]))))

--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -164,4 +164,7 @@
 
       (meh (net/heal! (:net test) test)))
 
-    (teardown! [_ test node])))
+    (teardown! [_ test node])
+
+    (install-build-essential! [_]
+      (install [:build-essential]))))


### PR DESCRIPTION
Had to override build essentials installation for CentOS in order to solve https://github.com/jepsen-io/jepsen/issues/271. 