### PR TITLE
core: Broaden catch when reconnecting

### DIFF
--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -383,7 +383,7 @@
               (try
                 ; Open a new client
                 (set! (.client this) (client/open! (:client test) test node))
-                (catch RuntimeException e
+                (catch Exception e
                   (warn e "Error opening client")
                   (let [fail (assoc op
                                     :type  :fail


### PR DESCRIPTION
Most operations are run with blanket `catch Exception` blocks (such as
CockroachDB's `c/with-exception->op`). This one, however, only catches
RuntimeException, any any non-runtime exceptions will escape and be
reported as a test failure. In particular, CockroachDB sees
InterruptedExceptions here with some regularity.

Fixes cockroachdb/cockroach#26279