### PR TITLE
Improvements in Dgraph tests

### DIFF
--- a/dgraph/project.clj
+++ b/dgraph/project.clj
@@ -9,7 +9,7 @@
                  [cheshire "5.8.0"]
                  ; Note that we specify manual versions of dgraph deps since
                  ; grpc uses version ranges
-                 [io.dgraph/dgraph4j "1.3.0"
+                 [io.dgraph/dgraph4j "1.6.0"
                   :exclusions [io.grpc/grpc-core
                                io.netty/netty-codec-http2]]
                  [io.grpc/grpc-core "1.10.0"]

--- a/dgraph/project.clj
+++ b/dgraph/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [jepsen "0.1.9"]
+                 [jepsen "0.1.10-SNAPSHOT"]
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]
                  ; Note that we specify manual versions of dgraph deps since
@@ -14,6 +14,9 @@
                                io.netty/netty-codec-http2]]
                  [io.grpc/grpc-core "1.10.0"]
                  [io.netty/netty-codec-http2 "4.1.16.Final"]
-                 [clj-wallhack "1.0.1"]]
+                 [clj-wallhack "1.0.1"]
+                 [io.opencensus/opencensus-api  "0.15.1"]
+                 [io.opencensus/opencensus-impl "0.15.1"]
+                 [io.opencensus/opencensus-exporter-trace-logging "0.15.1"]]
   :main jepsen.dgraph.core
   :profiles {:uberjar {:aot :all}})

--- a/dgraph/project.clj
+++ b/dgraph/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [jepsen "0.1.10-SNAPSHOT"]
+                 [jepsen "0.1.11-SNAPSHOT"]
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]
                  ; Note that we specify manual versions of dgraph deps since

--- a/dgraph/src/jepsen/dgraph/bank.clj
+++ b/dgraph/src/jepsen/dgraph/bank.clj
@@ -4,7 +4,8 @@
   (:require [clojure.tools.logging :refer [info]]
             [clojure.string :as str]
             [dom-top.core :refer [disorderly with-retry assert+]]
-            [jepsen.dgraph [client :as c]]
+            [jepsen.dgraph [client :as c]
+                           [trace :as t]]
             [jepsen [client :as client]
                     [generator :as generator]]
             [jepsen.tests.bank :as bank])
@@ -38,132 +39,149 @@
   all accounts across all type predicates. Returns a map of keys to amounts."
   ; All predicates
   ([t]
-   (->> (c/gen-preds "type" pred-count)
-        (map (partial read-accounts t))
-        (reduce merge)))
+   (t/with-trace "read-accounts"
+     (->> (c/gen-preds "type" pred-count)
+          (map (partial read-accounts t))
+          (reduce merge))))
   ; One predicate in particular
   ([t type-predicate]
-   (let [q (str "{ q(func: eq(" type-predicate ", $type)) {\n"
-                (->> (concat (c/gen-preds "key"    pred-count)
-                             (c/gen-preds "amount" pred-count))
-                     (str/join "\n"))
-                "}}")]
-     (->> (c/query t q {:type "account"})
-          :q
-          ;((fn [x] (info :read-val (pr-str x)) x))
-          (map multi-pred-acct->key+amount)
-          (into (sorted-map))))))
+   (t/with-trace "read-accounts "
+     (let [q (str "{ q(func: eq(" type-predicate ", $type)) {\n"
+                  (->> (concat (c/gen-preds "key"    pred-count)
+                               (c/gen-preds "amount" pred-count))
+                       (str/join "\n"))
+                  "}}")]
+       (->> (c/query t q {:type "account"})
+            :q
+                                        ;((fn [x] (info :read-val (pr-str x)) x))
+            (map multi-pred-acct->key+amount)
+            (into (sorted-map)))))))
 
 (defn find-account
   "Finds an account by key. Returns an empty account when none exists."
   [t k]
-  (let [kp (c/gen-pred "key"    pred-count k)
-        ap (c/gen-pred "amount" pred-count k)]
-    (let [r (-> (c/query t
-                         (str "{ q(func: eq(" kp ", $key)) { uid "
-                              kp " " ap " } } ")
-                         {:key k})
-                :q
-                first)]
-      (if r
-        ; Note that we need :type for new accounts, but don't want to update it
-        ; normally.
-        {:uid    (:uid r)
-         :key    (get r (keyword kp))
-         :amount (get r (keyword ap))}
-        ; Default account object when none exists
-        {:key     k
-         :type    "account"
-         :amount  0}))))
+  (t/with-trace "find-account"
+    (let [kp (c/gen-pred "key"    pred-count k)
+          ap (c/gen-pred "amount" pred-count k)]
+      (let [r (-> (c/query t
+                           (str "{ q(func: eq(" kp ", $key)) { uid "
+                                kp " " ap " } } ")
+                           {:key k})
+                  :q
+                  first)]
+        (if r
+                                        ; Note that we need :type for new accounts, but don't want to update it
+                                        ; normally.
+          {:uid    (:uid r)
+           :key    (get r (keyword kp))
+           :amount (get r (keyword ap))}
+                                        ; Default account object when none exists
+          {:key     k
+           :type    "account"
+           :amount  0})))))
 
 (defn write-account!
   "Writes back an account map."
   [t account]
-  (if (zero? (:amount account))
-    (c/delete! t (assert+ (:uid account)))
-    (let [k (assert+ (:key account))
-          kp (c/gen-pred "key"    pred-count k)
-          ap (c/gen-pred "amount" pred-count k)
-          tp (c/gen-pred "type"   pred-count k)]
-      (c/mutate! t (-> account
-                       (select-keys [:uid])
-                       (assoc (keyword tp) (:type account))
-                       (assoc (keyword kp) (:key account))
-                       (assoc (keyword ap) (:amount account)))))))
+  (t/with-trace "write-account"
+    (if (zero? (:amount account))
+      (c/delete! t (assert+ (:uid account)))
+      (let [k (assert+ (:key account))
+            kp (c/gen-pred "key"    pred-count k)
+            ap (c/gen-pred "amount" pred-count k)
+            tp (c/gen-pred "type"   pred-count k)]
+        (c/mutate! t (-> account
+                         (select-keys [:uid])
+                         (assoc (keyword tp) (:type account))
+                         (assoc (keyword kp) (:key account))
+                         (assoc (keyword ap) (:amount account))))))))
 
 (defrecord Client [conn]
   client/Client
   (open! [this test node]
-    (assoc this :conn (c/open node)))
+    (t/with-trace "bank.open"
+      (assoc this :conn (c/open node))))
 
   (setup! [this test]
-    ; Set up schemas
-    (->> (concat
-           ; Key schemas
-           (map (fn [pred]
-                  (str pred ": int @index(int)"
-                       (when (:upsert-schema test)
-                         " @upsert")
-                       " .\n"))
-                (c/gen-preds "key" pred-count))
+    ;; Set up schemas
+    (t/with-trace "bank.setup"
+      (->> (concat
+            ;; Key schemas
+            (map (fn [pred]
+                   (str pred ": int @index(int)"
+                        (when (:upsert-schema test)
+                          " @upsert")
+                        " .\n"))
+                 (c/gen-preds "key" pred-count))
 
-           ; Type schemas
-           (map (fn [pred]
-                  (str pred ": string @index(exact) .\n"))
-                (c/gen-preds "type" pred-count))
+            ;; Type schemas
+            (map (fn [pred]
+                   (str pred ": string @index(exact) .\n"))
+                 (c/gen-preds "type" pred-count))
 
-           ; Amount schemas
-           (map (fn [pred]
-                  (str pred ": int .\n"))
-                (c/gen-preds "amount" pred-count)))
-         str/join
-         (c/alter-schema! conn))
-    (info "Schema altered")
+            ;; Amount schemas
+            (map (fn [pred]
+                   (str pred ": int .\n"))
+                 (c/gen-preds "amount" pred-count)))
+           str/join
+           (c/alter-schema! conn))
+      (info "Schema altered")
 
-    ; Insert initial value
-    (try
-      (c/with-txn test [t conn]
-        (let [k (first (:accounts test))
-              tp (keyword (c/gen-pred "type"    pred-count k))
-              kp (keyword (c/gen-pred "key"     pred-count k))
-              ap (keyword (c/gen-pred "amount"  pred-count k))
-              r  {kp k
-                  tp "account",
-                  ap (:total-amount test)}]
-          (info "Upserting" r)
-          (c/upsert! t kp r)))
-      (catch TxnConflictException e)))
+      ;; Insert initial value
+      (try
+        (c/with-txn test [t conn]
+          (let [k (first (:accounts test))
+                tp (keyword (c/gen-pred "type"    pred-count k))
+                kp (keyword (c/gen-pred "key"     pred-count k))
+                ap (keyword (c/gen-pred "amount"  pred-count k))
+                r  {kp k
+                    tp "account",
+                    ap (:total-amount test)}]
+            (info "Upserting" r)
+            (c/upsert! t kp r)))
+        (catch TxnConflictException e))))
 
   (invoke! [this test op]
-    (c/with-conflict-as-fail op
-      (c/with-txn test [t conn]
-        (case (:f op)
-          :read (assoc op :type :ok, :value (read-accounts t))
+    (t/with-trace "bank.invoke"
+      (c/with-conflict-as-fail op
+        (c/with-txn test [t conn]
+          (case (:f op)
+            :read (t/with-trace "bank.invoke.read"
+                    (let [op (assoc op
+                                    :type :ok
+                                    :value (read-accounts t))]
+                      (if-let [error (bank/check-op (set (:accounts test))
+                                                    (:total-amount test)
+                                                    op)]
+                        (assoc op :message (dissoc error :op))
+                        op)))
 
-          :transfer (let [{:keys [from to amount]} (:value op)
-                          [from to] (disorderly
-                                      (find-account t from)
-                                      (find-account t to))
-                          _ (info :from (pr-str from))
-                          _ (info :to   (pr-str to))
-                          from' (update from :amount - amount)
-                          to'   (update to   :amount + amount)]
-                      (disorderly
-                        (write-account! t from')
-                        (write-account! t to'))
-                      (if (neg? (:amount from'))
-                        ; Whoops! Back out! Hey let's write some garbage just
-                        ; to make things fun.
-                        (do (write-account! t (update from' :amount - 1000))
-                            (write-account! t (update to'   :amount - 1000))
-                            (c/abort-txn! t)
-                           (assoc op :type :fail, :error :insufficient-funds))
-                        (assoc op :type :ok)))))))
+            :transfer (t/with-trace "bank.invoke.transfer"
+                        (let [{:keys [from to amount]} (:value op)
+                              [from to] (disorderly
+                                         (find-account t from)
+                                         (find-account t to))
+                              _ (info :from (pr-str from))
+                              _ (info :to   (pr-str to))
+                              from' (update from :amount - amount)
+                              to'   (update to   :amount + amount)]
+                          (disorderly
+                           (write-account! t from')
+                           (write-account! t to'))
+                          (if (neg? (:amount from'))
+                            ;; Whoops! Back out! Hey let's write some garbage just
+                            ;; to make things fun.
+                            (do (write-account! t (update from' :amount - 1000))
+                                (write-account! t (update to'   :amount - 1000))
+                                (c/abort-txn! t)
+                                (assoc op :type :fail, :error :insufficient-funds))
+                            (assoc op :type :ok)))))))))
 
   (teardown! [this test])
 
   (close! [this test]
-    (c/close! conn)))
+    (t/with-trace "bank.close"
+      (c/close! conn))))
 
 (defn workload
   "Stuff you need to build a test!"

--- a/dgraph/src/jepsen/dgraph/bank.clj
+++ b/dgraph/src/jepsen/dgraph/bank.clj
@@ -37,13 +37,13 @@
   "Given a transaction, reads all accounts. If a type predicate is provided,
   finds all accounts where that type predicate is \"account\". Otherwise, finds
   all accounts across all type predicates. Returns a map of keys to amounts."
-  ; All predicates
+  ;; All predicates
   ([t]
    (t/with-trace "read-accounts"
      (->> (c/gen-preds "type" pred-count)
           (map (partial read-accounts t))
           (reduce merge))))
-  ; One predicate in particular
+  ;; One predicate in particular
   ([t type-predicate]
    (t/with-trace "read-accounts "
      (let [q (str "{ q(func: eq(" type-predicate ", $type)) {\n"
@@ -53,7 +53,7 @@
                   "}}")]
        (->> (c/query t q {:type "account"})
             :q
-                                        ;((fn [x] (info :read-val (pr-str x)) x))
+            ;;((fn [x] (info :read-val (pr-str x)) x))
             (map multi-pred-acct->key+amount)
             (into (sorted-map)))))))
 
@@ -70,12 +70,12 @@
                   :q
                   first)]
         (if r
-                                        ; Note that we need :type for new accounts, but don't want to update it
-                                        ; normally.
+          ;; Note that we need :type for new accounts, but don't want to update it
+          ;; normally.
           {:uid    (:uid r)
            :key    (get r (keyword kp))
            :amount (get r (keyword ap))}
-                                        ; Default account object when none exists
+          ;; Default account object when none exists
           {:key     k
            :type    "account"
            :amount  0})))))
@@ -153,7 +153,9 @@
                       (if-let [error (bank/check-op (set (:accounts test))
                                                     (:total-amount test)
                                                     op)]
-                        (assoc op :message (dissoc error :op))
+                        (assoc op
+                               :message (dissoc error :op)
+                               :error :checker-violation)
                         op)))
 
             :transfer (t/with-trace "bank.invoke.transfer"
@@ -180,8 +182,7 @@
   (teardown! [this test])
 
   (close! [this test]
-    (t/with-trace "bank.close"
-      (c/close! conn))))
+    (c/close! conn)))
 
 (defn workload
   "Stuff you need to build a test!"

--- a/dgraph/src/jepsen/dgraph/core.clj
+++ b/dgraph/src/jepsen/dgraph/core.clj
@@ -112,8 +112,7 @@
    [nil "--replicas COUNT" "How many replicas of data should dgraph store?"
     :default 3
     :parse-fn parse-long
-    ;:validate [pos? "Must be a positive integer"]
-    ]
+    :validate [pos? "Must be a positive integer"]]
    [nil "--rebalance-interval TIME" "How long before automatic rebalances"
     :default "10s"]
    [nil "--final-recovery-time SECONDS" "How long to wait for the cluster to stabilize at the end of a test"

--- a/dgraph/src/jepsen/dgraph/core.clj
+++ b/dgraph/src/jepsen/dgraph/core.clj
@@ -112,7 +112,8 @@
    [nil "--replicas COUNT" "How many replicas of data should dgraph store?"
     :default 3
     :parse-fn parse-long
-    :validate [pos? "Must be a positive integer"]]
+    ;:validate [pos? "Must be a positive integer"]
+    ]
    [nil "--rebalance-interval TIME" "How long before automatic rebalances"
     :default "10s"]
    [nil "--final-recovery-time SECONDS" "How long to wait for the cluster to stabilize at the end of a test"

--- a/dgraph/src/jepsen/dgraph/trace.clj
+++ b/dgraph/src/jepsen/dgraph/trace.clj
@@ -2,20 +2,22 @@
   (:import (io.opencensus.trace Tracer
                                 Tracing
                                 Span)
+           (io.opencensus.trace.samplers Samplers)
            (io.opencensus.exporter.trace.logging LoggingTraceExporter)))
 
-;; Ok so, this is entirely done with globals, which skeevs me out
-;; cause I haven't been able to guarantee that a tracer can be global. BUT
-;; the docs and examples seeeeeem to imply that it is. Also there's
-;; HOPEFULLY everything works hard to tell without seeing exports
-;; *shakes fist at LoggingTraceExporter* Anyway, if it does work this is
-;; a HELL of a lot simpler than having to pass it tracers everywhere.
-
 (def tracer ^Tracer (Tracing/getTracer))
-;; TODO Why the hecky isn't this logging??
 (def trace-exporter (LoggingTraceExporter/register))
 
-;; TODO TraceConfig
+;; TODO Set a higher sample rate
+#_(def trace-config
+  (let [sampler (Samplers/alwaysSample)
+        config  (Tracing/getTraceConfig)
+        config' (->> config
+                    .getActiveTraceParams
+                    .toBuilder
+                    (.setSampler sampler)
+                    .build)]
+    (.updateActiveTraceParams config')))
 
 (defmacro with-trace
   "Takes a span name and a body and uses this namespace's tracer to

--- a/dgraph/src/jepsen/dgraph/trace.clj
+++ b/dgraph/src/jepsen/dgraph/trace.clj
@@ -1,0 +1,27 @@
+(ns jepsen.dgraph.trace
+  (:import (io.opencensus.trace Tracer
+                                Tracing
+                                Span)
+           (io.opencensus.exporter.trace.logging LoggingTraceExporter)))
+
+;; Ok so, this is entirely done with globals, which skeevs me out
+;; cause I haven't been able to guarantee that a tracer can be global. BUT
+;; the docs and examples seeeeeem to imply that it is. Also there's
+;; HOPEFULLY everything works hard to tell without seeing exports
+;; *shakes fist at LoggingTraceExporter* Anyway, if it does work this is
+;; a HELL of a lot simpler than having to pass it tracers everywhere.
+
+(def tracer ^Tracer (Tracing/getTracer))
+;; TODO Why the hecky isn't this logging??
+(def trace-exporter (LoggingTraceExporter/register))
+
+;; TODO TraceConfig
+
+(defmacro with-trace
+  "Takes a span name and a body and uses this namespace's tracer to
+  wrap the body in a span."
+  [name & body]
+  `(let [span# (-> tracer (.spanBuilder ~name) .startScopedSpan)]
+     (try
+       ~@body
+       (finally (.close span#)))))

--- a/dgraph/src/jepsen/dgraph/trace.clj
+++ b/dgraph/src/jepsen/dgraph/trace.clj
@@ -8,16 +8,19 @@
 (def tracer ^Tracer (Tracing/getTracer))
 (def trace-exporter (LoggingTraceExporter/register))
 
-;; TODO Set a higher sample rate
-#_(def trace-config
-  (let [sampler (Samplers/alwaysSample)
-        config  (Tracing/getTraceConfig)
-        config' (->> config
-                    .getActiveTraceParams
-                    .toBuilder
-                    (.setSampler sampler)
-                    .build)]
-    (.updateActiveTraceParams config')))
+;; TODO Add a CLI input for choosing between samplers
+(def sampler ^Sampler
+  #_(Samplers/alwaysSample)
+  (Samplers/neverSample))
+
+(def trace-config
+  (let [config (Tracing/getTraceConfig)
+        params (-> config
+                   .getActiveTraceParams
+                   .toBuilder
+                   (.setSampler sampler)
+                   .build)]
+    (.updateActiveTraceParams config params)))
 
 (defmacro with-trace
   "Takes a span name and a body and uses this namespace's tracer to

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.1.10-SNAPSHOT"
+(defproject jepsen "0.1.11-SNAPSHOT"
   :description "Distributed systems testing framework."
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.1.10"
+(defproject jepsen "0.1.10-SNAPSHOT"
   :description "Distributed systems testing framework."
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}

--- a/jepsen/src/jepsen/tests/bank.clj
+++ b/jepsen/src/jepsen/tests/bank.clj
@@ -54,41 +54,46 @@
                                         (:total-amount test))))
     :negative-value (- (reduce + (:negative err)))))
 
+(defn check-op
+  "Takes a single op and returns errors in its balance"
+  [accts total op]
+  (let [ks       (keys (:value op))
+        balances (vals (:value op))]
+    (cond (not-every? accts ks)
+          {:type        :unexpected-key
+           :unexpected  (remove accts ks)
+           :op          op}
+
+          (some nil? balances)
+          {:type    :nil-balance
+           :nils    (->> (:value op)
+                         (remove val)
+                         (into {}))
+           :op      op}
+
+          (not= total
+                (reduce + balances))
+          {:type     :wrong-total
+           :total    (reduce + balances)
+           :op       op}
+
+          (some neg? balances)
+          {:type     :negative-value
+           :negative (filter neg? balances)
+           :op       op})))
+
 (defn checker
-	"Balances must all be non-negative and sum to (:total test)."
+  "Balances must all be non-negative and sum to (:total test)."
   []
   (reify checker/Checker
     (check [this test model history opts]
-      (let [accts     (set (:accounts test))
+      (let [accts (set (:accounts test))
+            total (:total-amount test)
             reads (->> history
                        (r/filter op/ok?)
                        (r/filter #(= :read (:f %))))
             errors (->> reads
-                        (r/map (fn [op]
-                                 (let [ks       (keys (:value op))
-                                       balances (vals (:value op))]
-                                   (cond (not-every? accts ks)
-                                         {:type        :unexpected-key
-                                          :unexpected  (remove accts ks)
-                                          :op          op}
-
-                                         (some nil? balances)
-                                         {:type    :nil-balance
-                                          :nils    (->> (:value op)
-                                                        (remove val)
-                                                        (into {}))
-                                          :op      op}
-
-                                         (not= (:total-amount test)
-                                               (reduce + balances))
-                                         {:type     :wrong-total
-                                          :total    (reduce + balances)
-                                          :op       op}
-
-                                         (some neg? balances)
-                                         {:type     :negative-value
-                                          :negative (filter neg? balances)
-                                          :op       op}))))
+                        (r/map #(check-op accts total %))
                         (r/filter identity)
                         (group-by :type))]
         {:valid?      (every? empty? (vals errors))


### PR DESCRIPTION
Bunch of changes in here, mostly in the client and bank tests

- Pull `jepsen.tests.bank/check-op` into a function so it may be called from bank test clients inline

- Bump Dgraph client to version 1.6.0, various changes for compatibility
- Add optional tracing to (almost) all of jepsen.dgraph.client and jepsen.dgraph.bank
- Call `jepsen.tests.bank/check-op` on each bank test read to catch errors as they occur. Useful point to include extra context or halt the test in the future.