### PR TITLE
generator: Catch InterruptedException in delay

### DIFF
--- a/jepsen/src/jepsen/generator.clj
+++ b/jepsen/src/jepsen/generator.clj
@@ -166,7 +166,10 @@
 (defgenerator DelayFn [f gen]
   [f gen]
   (op [_ test process]
-      (Thread/sleep (* 1000 (f)))
+      (try
+        (Thread/sleep (* 1000 (f)))
+        (catch InterruptedException e
+          nil))
       (op gen test process)))
 
 (defn delay-fn


### PR DESCRIPTION
Generator functions are called without any other try/catch
wrapper (unlike most client code which has a blanket catch clause).
gen/delay is interruptible and is a cause of spurious failures during
shutdown (cockroachdb/cockroach#30499).

Note that the approach taken here (proceed immediately when
interrupted) is different from that used in gen/delay-til (which uses
LockSupport/parkNanos for an uninterruptible sleep).

