### PR TITLE
[GH-300] Revert "Fix checker function call"

### DIFF
--- a/rabbitmq/test/jepsen/rabbitmq_test.clj
+++ b/rabbitmq/test/jepsen/rabbitmq_test.clj
@@ -23,8 +23,8 @@
 ;                 :os        debian/os
 ;                 :db        db
 ;                 :client    (mutex)
-;                 :checker   (checker/compose {:html   (timeline/html)
-;                                              :linear (checker/linearizable)})
+;                 :checker   (checker/compose {:html   timeline/html
+;                                              :linear checker/linearizable})
 ;                 :model     (model/mutex)
 ;                 :nemesis   (nemesis/partition-random-halves)
 ;                 :generator (gen/phases
@@ -54,8 +54,8 @@
                  :nemesis    (nemesis/partition-random-halves)
                  :model      (model/unordered-queue)
                  :checker    (checker/compose
-                               {:queue       (checker/queue)
-                                :total-queue (checker/total-queue)})
+                               {:queue       checker/queue
+                                :total-queue checker/total-queue})
                  :generator  (gen/phases
                                (->> (gen/queue)
                                     (gen/delay 1/10)


### PR DESCRIPTION
Unless jepsen version is also updated (with couple of other
changes implied by jepsen version change), this breaks existing
test.

This reverts commit 2c607aea058c67d41e69f1092f65281fb0af745d.