### PR TITLE
control, doc: warn user when creating an ssh-session with keyword host

### DIFF
--- a/doc/plan.md
+++ b/doc/plan.md
@@ -38,8 +38,6 @@
 
 - Deprecate model argument in checker; these should be arguments to checker
   constructors instead.
-- Deprecate keyword hosts; this was a silly idea and the minor improvement
-  in readability isn't really worth it.
 - Clean up checker/counter: remove failed ops in an initial pre-pass, rather
   than adding them then undoing those adds.
 - Macro like (synchronize-nodes test), which enforces a synchronization

--- a/jepsen/src/jepsen/control.clj
+++ b/jepsen/src/jepsen/control.clj
@@ -265,10 +265,22 @@
   `(binding [*trace* true]
      ~@body))
 
+(defn check-name
+  "Ensures a given hostname is string. Warns user if legacy behavior passes in a
+  keyword host.
+  TODO This can be removed when tests no tests generate keyword hosts. CLI already
+       refuses keyword hostnames."
+  [host]
+  (when (keyword? host)
+    (warn (str "DEPRECATED: Host "
+               host
+               " is a keyword; please provide node hostnames as strings. Support for keyword hosts will be removed in future versions of jepsen.")))
+  (name host))
+
 (defn clj-ssh-session
   "Opens a raw session to the given host."
   [host]
-  (let [host  (name host)
+  (let [host  (check-name host)
         agent (ssh/ssh-agent {})
         _     (when *private-key-path*
                 (ssh/add-identity agent


### PR DESCRIPTION
Changes last year already prevent parsing of keyword hosts from CLI input. Now we warn users when a keyword gets passed in to `jepsen.control.clj-ssh-session`. Mongodb-smartos, cockroachdb, and logcabin still use the keyword host feature. (found by searching for :n1)