### PR TITLE
checker/counter: pre-process history to remove failed ops

### DIFF
--- a/jepsen/test/jepsen/checker_test.clj
+++ b/jepsen/test/jepsen/checker_test.clj
@@ -4,7 +4,7 @@
         clojure.test)
   (:require [knossos [history :as history]
                      [model :as model]
-                     [core :refer [ok-op invoke-op]]]
+                     [core :refer [ok-op invoke-op fail-op]]]
             [multiset.core :as multiset]
             [jepsen.checker.perf :refer :all]))
 
@@ -95,6 +95,17 @@
   (testing "initial read"
     (is (= (check (counter) nil nil
                   [(invoke-op 0 :read nil)
+                   (ok-op     0 :read 0)]
+                  {})
+           {:valid? true
+            :reads  [[0 0 0]]
+            :errors []})))
+
+  (testing "ignore failed ops"
+    (is (= (check (counter) nil nil
+                  [(invoke-op 0 :add 1)
+                   (fail-op   0 :add 1)
+                   (invoke-op 0 :read nil)
                    (ok-op     0 :read 0)]
                   {})
            {:valid? true


### PR DESCRIPTION
Removed both the invocation and completion of failed ops so we didn't wind up with histories missing invocations. It's a touch more expensive, but you never know we might end up composing checkers 🤷‍♀️ 

This will conflict with #311, so let me handle merging if both are approved.

Something to note is that the tests for "interleaved and concurrent reads" and "rolling reads and writes" do not pass with their expected values. I dug into it enough to ensure that this PR didn't affect the behavior. But it's not clear to me if the current behavior or the tested-for behavior is preferable. Worth a look, and I can make changes to the two tests or checker if you want.