### PR TITLE
CI: add travis.yml and :integration flags for tests

### DIFF
--- a/jepsen/.travis.yml
+++ b/jepsen/.travis.yml
@@ -1,0 +1,11 @@
+language: clojure
+lein: lein
+dist: xenial
+jdk:
+   - oraclejdk10
+   - oraclejdk11
+   - oraclejdk12
+branches:
+  only:
+    - master
+script: lein do clean, test

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -32,6 +32,8 @@
              "-XX:+UseFastAccessorMethods" "-server"
              ;"-XX:-OmitStackTraceInFastThrow"
              ]
+  :test-selectors {:default (complement :integration)
+                   :integration :integration}
   :codox {:output-path "doc/"
           :source-uri "https://github.com/jepsen-io/jepsen/blob/{version}/jepsen/{filepath}#L{line}"
           :metadata {:doc/format :markdown}})

--- a/jepsen/test/jepsen/control_test.clj
+++ b/jepsen/test/jepsen/control_test.clj
@@ -2,7 +2,7 @@
   (:require [jepsen.control :as c]
             [clojure.test :refer :all]))
 
-(deftest basic-test
+(deftest ^:integration basic-test
   (c/with-ssh {}
     (c/on "n1"
           (is (= (c/exec :whoami) "root")))))

--- a/jepsen/test/jepsen/store_test.clj
+++ b/jepsen/test/jepsen/store_test.clj
@@ -16,7 +16,7 @@
                       :multiset (into (multiset/multiset)
                                       [1 1 2 3 5 8])))
 
-(deftest roundtrip-test
+(deftest ^:integration roundtrip-test
   (delete! "store-test")
 
   (let [t (-> base-test


### PR DESCRIPTION
Runs everything _not_ flagged with :integration by default. :integration tests can be run when the control node has access to nodes.