### PR TITLE
control,util: slingshot throw debug data from jepsen.control

### DIFF
--- a/jepsen/src/jepsen/util.clj
+++ b/jepsen/src/jepsen/util.clj
@@ -766,3 +766,6 @@
   of the body."
   [locks name & body]
   `(locking (get-named-lock! ~locks ~name) ~@body))
+
+(defn contains-many? [m & ks]
+  (every? #(contains? m %) ks))

--- a/jepsen/src/jepsen/util.clj
+++ b/jepsen/src/jepsen/util.clj
@@ -767,5 +767,8 @@
   [locks name & body]
   `(locking (get-named-lock! ~locks ~name) ~@body))
 
-(defn contains-many? [m & ks]
+(defn contains-many?
+  "Takes a map and any number of keys, returning true if all of the keys are
+  present. Ex. (contains-many? {:a 1 :b 2 :c 3} :a :b :c) => true"
+  [m & ks]
   (every? #(contains? m %) ks))

--- a/jepsen/test/jepsen/control_test.clj
+++ b/jepsen/test/jepsen/control_test.clj
@@ -1,8 +1,27 @@
 (ns jepsen.control-test
   (:require [jepsen.control :as c]
-            [clojure.test :refer :all]))
+            [slingshot.slingshot :refer [try+ throw+]]
+            [clojure.test :refer :all]
+            [jepsen.util :refer [contains-many?]]))
 
-(deftest ^:integration basic-test
-  (c/with-ssh {}
-    (c/on "n1"
-          (is (= (c/exec :whoami) "root")))))
+(deftest ^:integration session-test
+  (testing "on failure, session throws debug data"
+    (try+
+     (c/with-ssh {}
+       (c/on "thishostshouldnotresolve"
+             (c/exec :echo "hello")))
+     (catch Object m
+       (is (contains-many? m :dir :username :port :host))))))
+
+(deftest ^:integration exec-test
+  (testing "simple exec"
+    (c/with-ssh {}
+      (c/on "n1"
+            (is (= (c/exec :whoami) "root")))))
+
+  (testing "on failure, exec throws debug data"
+    (try+
+     (c/with-ssh {}
+       (c/on "n1" (c/exec :thiscmdshouldnotexist)))
+     (catch Object m
+       (is (contains-many? m :cmd :out :err :host :exit))))))


### PR DESCRIPTION
Also Moved over from the `jepsen.util/with-retry` to the dom-top version, as per recent tests.