### PR TITLE
checker.perf: render nemeses as gantt charts. fix nemesis lines

### DIFF
--- a/jepsen/src/jepsen/checker/clock.clj
+++ b/jepsen/src/jepsen/checker/clock.clj
@@ -63,7 +63,7 @@
               (perf/preamble output-path)
               [[:set :title (str (:name test) " clock skew")]
                [:set :ylabel "Skew (s)"]]
-              (perf/nemesis-regions history)
+              (perf/nemesis-regions* history)
               (perf/nemesis-lines history)
               [['plot (apply g/list
                              (for [node node-names]

--- a/jepsen/src/jepsen/checker/perf.clj
+++ b/jepsen/src/jepsen/checker/perf.clj
@@ -210,12 +210,11 @@
    (let [fill-color     (or (:fill-color   opts) "#000000")
          transparency   (or (:transparency opts) 0.1)
          history        (nemesis-intervals history opts)
-         name           (:name opts)
          graph-top-edge 1
          ;; Divide our y-axis space into twelfths
          height         0.0834
          padding        0.00615
-         idx            (inc (:idx opts))
+         idx            (inc (or (:idx opts) 0))
          bot            (- graph-top-edge
                            (* height idx))
          top            (+ bot height)]

--- a/jepsen/test/jepsen/checker_test.clj
+++ b/jepsen/test/jepsen/checker_test.clj
@@ -279,6 +279,60 @@
                 :rate-graph {:valid? true},
                 :valid? true}))))
 
+    (testing "can render single nemesis events as bars"
+      (let [checker (perf {:nemeses #{{:name "solo nemeses"}}})
+            test    {:name "nemeses solo event"
+                     :start-time 0}
+            nemesis-ops [{:type :info
+                          :process :nemesis
+                          :f :nemesize
+                          :value :spooky!
+                          :time (* 1e9 20)}
+                         {:type :info
+                          :process :nemesis
+                          :f :nemesize
+                          :value :woah!
+                          :time (* 1e9 80)}]
+            history (apply conj history nemesis-ops)]
+        (is (= (check checker test history {})
+               {:latency-graph {:valid? true},
+                :rate-graph {:valid? true},
+                :valid? true}))))
+
+    (testing "can render nemeses with custom styling"
+      (let [checker (perf {:nemeses #{{:name "cool nemesis 8)"
+                                       :fill-color "#6DB6FE"
+                                       :transparency 0.5
+                                       :line-color "#6DB6FE"
+                                       :line-width 2}}})
+            test    {:name "nemeses styling perf test"
+                     :start-time 0}
+            nemesis-ops [{:type :info
+                          :process :nemesis
+                          :f :start
+                          :value nil
+                          :time (* 1e9 5)}
+                         {:type :info
+                          :process :nemesis
+                          :f :start
+                          :value [:isolated {"n2" #{"n1" "n4" "n3"}, "n5" #{"n1" "n4" "n3"}, "n1" #{"n2" "n5"}, "n4" #{"n2" "n5"}, "n3" #{"n2" "n5"}}]
+                          :time (* 1e9 20)}
+                         {:type :info
+                          :process :nemesis
+                          :f :stop
+                          :value nil
+                          :time (* 1e9 50)}
+                         {:type :info
+                          :process :nemesis
+                          :f :stop
+                          :value :network-healed
+                          :time (* 1e9 90)}]
+            history (apply conj history nemesis-ops)]
+        (is (= (check checker test history {})
+               {:latency-graph {:valid? true},
+                :rate-graph {:valid? true},
+                :valid? true}))))
+
     (testing "can render multiple nemesis regions"
       (let [checker (perf {:nemeses #{{:name "1"
                                        :start #{:start1}
@@ -335,40 +389,6 @@
                           :f :stop2.1
                           :value :network-healed
                           :time (* 1e9 95)}]
-            history (apply conj history nemesis-ops)]
-        (is (= (check checker test history {})
-               {:latency-graph {:valid? true},
-                :rate-graph {:valid? true},
-                :valid? true}))))
-
-    (testing "can render nemeses with custom styling"
-      (let [checker (perf {:nemeses #{{:name "cool nemesis 8)"
-                                       :fill-color "#6DB6FE"
-                                       :transparency 0.5
-                                       :line-color "#6DB6FE"
-                                       :line-width 2}}})
-            test    {:name "nemeses styling perf test"
-                     :start-time 0}
-            nemesis-ops [{:type :info
-                          :process :nemesis
-                          :f :start
-                          :value nil
-                          :time (* 1e9 5)}
-                         {:type :info
-                          :process :nemesis
-                          :f :start
-                          :value [:isolated {"n2" #{"n1" "n4" "n3"}, "n5" #{"n1" "n4" "n3"}, "n1" #{"n2" "n5"}, "n4" #{"n2" "n5"}, "n3" #{"n2" "n5"}}]
-                          :time (* 1e9 20)}
-                         {:type :info
-                          :process :nemesis
-                          :f :stop
-                          :value nil
-                          :time (* 1e9 50)}
-                         {:type :info
-                          :process :nemesis
-                          :f :stop
-                          :value :network-healed
-                          :time (* 1e9 90)}]
             history (apply conj history nemesis-ops)]
         (is (= (check checker test history {})
                {:latency-graph {:valid? true},

--- a/jepsen/test/jepsen/checker_test.clj
+++ b/jepsen/test/jepsen/checker_test.clj
@@ -280,14 +280,16 @@
                 :valid? true}))))
 
     (testing "can render multiple nemesis regions"
-      (let [checker (perf {:nemeses #{{:start #{:start1}
+      (let [checker (perf {:nemeses #{{:name "1"
+                                       :start #{:start1}
                                        :stop  #{:stop1}
                                        :fill-color "#800080"
-                                       :transparency 0.1}
-                                      {:start #{:start2.1 :start2.2}
+                                       :transparency 0.2}
+                                      {:name "2"
+                                       :start #{:start2.1 :start2.2}
                                        :stop  #{:stop2.1 :stop2.2}
                                        :fill-color "#87A96B"
-                                       :transparency 0.1}}})
+                                       :transparency 0.2}}})
             test    {:name "nemeses multiregions perf test"
                      :start-time 0}
 
@@ -340,7 +342,8 @@
                 :valid? true}))))
 
     (testing "can render nemeses with custom styling"
-      (let [checker (perf {:nemeses #{{:fill-color "#6DB6FE"
+      (let [checker (perf {:nemeses #{{:name "cool nemesis 8)"
+                                       :fill-color "#6DB6FE"
                                        :transparency 0.5
                                        :line-color "#6DB6FE"
                                        :line-width 2}}})


### PR DESCRIPTION
Gantt charts for nemesis regions!

There's a few quirks here from limits in gnuplot:
- A nemesis must be given a name in its opts to show up in the legend. (I kept this behavior rather than giving nemeses default names so we don't have a phantom legend key when there are no nemeses)
- The nemesis keys in the legend have the same color as their regions but no transparency. Spent a while trying to get this one working with boxes (which should support transparency), but decided to go with lines because I could not get boxes to render colors correctly.

Also added a test that solo nemesis events render as bars.

Now for some examples 😎 😎 

![latency-quantiles](https://user-images.githubusercontent.com/938395/53385306-d703a880-3932-11e9-9771-95fb6f0aede2.png)

![latency-raw](https://user-images.githubusercontent.com/938395/53385343-ed116900-3932-11e9-93cd-eb3f6d0f6383.png)

![rate](https://user-images.githubusercontent.com/938395/53385282-bcc9ca80-3932-11e9-8a6d-02b02ae2a959.png)

![rate](https://user-images.githubusercontent.com/938395/53385362-031f2980-3933-11e9-801d-6de769c757e4.png)

Planning to squash on merge.