### PR TITLE
Introduce Jepsen tests for the new CP Subsystem module of Hazelcast IMDG

### DIFF
--- a/hazelcast/.gitignore
+++ b/hazelcast/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.idea/
+*.iml

--- a/hazelcast/README.md
+++ b/hazelcast/README.md
@@ -1,14 +1,82 @@
 # jepsen.hazelcast
 
-A Clojure library designed to ... well, that part is up to you.
+A Jepsen test suite for Hazelcast IMDG.
 
-## Usage
+## How to Use
 
-FIXME
+We run the Jepsen tests using docker containers for convenience.
+
+First, make sure that Docker is installed. To start Jepsen containers, execute the following command in `jepsen`
+directory which is one level up from `hazelcast` directory:
+
+    $ cd docker && ./up.sh
+
+Our Jepsen tests are ready to go once all containers are up and running fine. You can get into the `jepsen-control`
+container by executing the following command:
+
+    $ docker exec -it jepsen-control bash
+
+Then, while you are inside the `jepsen-control` container, run the following command:
+
+    $ cd hazelcast
+
+While you are at the `hazelcast` directory, you can run our Jepsen tests using `lein`. For instance,
+`lein run test --workload non-reentrant-cp-lock --time-limit 120` runs the non-reentrant lock test for 120 seconds.
+
+You can also use the `repeat` scripts to run tests multiple times. For instance, while in the `hazelcast` directory,
+run `sh repeat_single_test.sh non-reentrant-cp-lock 5 120` to run the non-reentrant CP lock test 5 times, each test taking 120
+seconds, or run `sh repeat_all_cp_tests.sh 5 120` to run the whole CP subsystem test suite 5 times, each test taking 120 seconds.
+These scripts stop on a test failure so that you can report and investigate the failure.
+
+## Test Cases
+
+With Hazelcast version 3.12, we released our Jepsen test suite for the CP data structures. Besides the new CP subsystem
+test suite, there are other tests written by Kyle Kingsbury to test AP data structures in Hazelcast.
+
+Our CP subsystem test suite is as follows:
+- Non-reentrant lock (`--workload non-reentrant-cp-lock`): In this test case, we test if the new `FencedLock`
+data structure behaves as a non-reentrant mutex, i.e., it can be held by a single endpoint at a time and only the lock
+holder endpoint can release it. Moreover, the lock cannot be acquired by the same endpoint reentrantly. It means that
+while a client holds the lock, it cannot acquire the lock again, without releasing the lock first.
+
+- Reentrant lock (`--workload reentrant-cp-lock`): We test if the new `FencedLock` data structure behaves as a reentrant
+mutex. The lock instance can be held by a single endpoint at a time and only the lock holder endpoint can release it.
+Moreover, the current lock holder can reentrantly acquire the lock one more time. Reentrant lock acquire limit is 2 for
+this test.
+
+- Non-reentrant fenced lock (`--workload non-reentrant-fenced-lock`): `FencedLock` orders lock holders by a monotonic
+fencing token, which is incremented each time the lock switches from the free state to the held state. In this test
+case, we validate monotonicity of fencing tokens assigned to subsequent lock holders. Moreover, the lock cannot be
+acquired by the same endpoint reentrantly. It means that while a client holds the lock, it cannot acquire the lock
+again, without releasing the lock first.
+
+- Reentrant fenced lock (`--workload reentrant-fenced-lock`): `FencedLock` orders lock holders by a monotonic fencing
+token, which is incremented each time the lock switches from the free state to the held state. However, if the current
+lock holder acquires the lock reentrantly, it will get the same fencing token. Reentrant lock acquire limit is 2 for
+this test.
+
+- Semaphore (`--workload semaphore`): In this test, we initialize our new linearizable `ISemaphore` with 2 permits. Each
+client acquires and releases a permit in a loop and we validate permits are held by at most 2 clients at a time.
+
+- Unique ID Generation with the new linearizable `IAtomicLong` (`--workload cp-id-gen-long`): In this test,
+each client generates a unique long id by using a linearizable `IAtomicLong` instance and we validate uniqueness of
+generated ids.
+
+- Compare-and-swap Register with the new linearizable `IAtomicLong` (`--workload cp-cas-long`): In this test,
+clients randomly perform write and compare-and-swap operations.
+
+- Compare-and-swap Register with the new linearizable `IAtomicReference` (`--workload cp-cas-reference`): In this test,
+clients randomly perform write and compare-and-swap operations.
+
+In each test, multiple clients send concurrent operations to a shared data structure, which is replicated
+to the Hazelcast cluster. In the mean time, Jepsen's `nemesis` injects network partitions into the system. At the end
+of the test, Jepsen validates if the history of operations is linearizable. We are planning to add more failure modes
+in future.
 
 ## License
 
-Copyright © 2017 FIXME
+Original work Copyright © 2015-2019, Jepsen, LLC
 
-Distributed under the Eclipse Public License either version 1.0 or (at
-your option) any later version.
+Modified work Copyright © 2019, Hazelcast, Inc. All Rights Reserved.
+
+Distributed under the Eclipse Public License version 1.0 or (at your option) any later version.

--- a/hazelcast/project.clj
+++ b/hazelcast/project.clj
@@ -1,9 +1,9 @@
 (defproject jepsen.hazelcast "0.1.0-SNAPSHOT"
-  :description "Jepsen tests for hazelcast"
+  :description "Jepsen tests for Hazelcast IMDG"
   :url "http://jepsen.io/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [jepsen "0.1.6"]
-                 [com.hazelcast/hazelcast-client "3.8"]]
+                 [jepsen "0.1.11"]
+                 [com.hazelcast/hazelcast-client "3.12-BETA-1"]]
   :main jepsen.hazelcast)

--- a/hazelcast/repeat_all_cp_tests.sh
+++ b/hazelcast/repeat_all_cp_tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+if [ $# != 2 ]; then
+	echo "how to use: ./repeat_all_cp_tests.sh repeat test_duration"
+	exit 1
+fi
+
+repeat=$1
+test_duration=$2
+
+run_single_test () {
+    test_name=$1
+    echo "running $test_name test"
+
+    lein run test --workload ${test_name} --time-limit ${test_duration}
+
+    if [ $? != '0' ]; then
+        echo "$test_name test failed"
+        exit 1
+    fi
+}
+
+round="1"
+
+while [ ${round} -le ${repeat} ]; do
+
+    echo "round: $round"
+
+    run_single_test "non-reentrant-cp-lock"
+    run_single_test "reentrant-cp-lock"
+    run_single_test "non-reentrant-fenced-lock"
+    run_single_test "reentrant-fenced-lock"
+    run_single_test "cp-semaphore"
+    run_single_test "cp-id-gen-long"
+    run_single_test "cp-cas-long"
+    run_single_test "cp-cas-reference"
+
+    round=`expr $round \+ 1`
+
+done

--- a/hazelcast/repeat_single_test.sh
+++ b/hazelcast/repeat_single_test.sh
@@ -8,21 +8,5 @@ fi
 test_name=$1
 repeat=$2
 test_duration=$3
-round="1"
 
-while [ ${round} -le ${repeat} ]; do
-
-    echo "round: $round"
-
-    echo "running $test_name test"
-
-    lein run test --workload ${test_name} --time-limit ${test_duration}
-
-    if [ $? != '0' ]; then
-        echo "$test_name test failed"
-        exit 1
-    fi
-
-    round=`expr $round \+ 1`
-
-done
+lein run test --workload ${test_name} --test-count ${repeat} --time-limit ${test_duration}

--- a/hazelcast/repeat_single_test.sh
+++ b/hazelcast/repeat_single_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+if [ $# != 3 ]; then
+	echo "how to use: ./repeat_single_test.sh test_name repeat test_duration"
+	exit 1
+fi
+
+test_name=$1
+repeat=$2
+test_duration=$3
+round="1"
+
+while [ ${round} -le ${repeat} ]; do
+
+    echo "round: $round"
+
+    echo "running $test_name test"
+
+    lein run test --workload ${test_name} --time-limit ${test_duration}
+
+    if [ $? != '0' ]; then
+        echo "$test_name test failed"
+        exit 1
+    fi
+
+    round=`expr $round \+ 1`
+
+done

--- a/hazelcast/server/project.clj
+++ b/hazelcast/server/project.clj
@@ -9,7 +9,7 @@
                  [org.clojure/tools.cli "0.3.5"]
                  [org.clojure/tools.logging "0.3.1"]
                  [spootnik/unilog "0.7.13"]
-                 [com.hazelcast/hazelcast "3.8.3"]]
+                 [com.hazelcast/hazelcast "3.12-BETA-1"]]
   :profiles {:uberjar {:uberjar-name "hazelcast-server.jar"}}
   :main jepsen.hazelcast-server
   :aot [jepsen.hazelcast-server])

--- a/hazelcast/server/src/jepsen/hazelcast_server.clj
+++ b/hazelcast/server/src/jepsen/hazelcast_server.clj
@@ -17,30 +17,28 @@
     :parse-fn (fn [m]
                   (str/split m #"\s*,\s*"))]])
 
-(defn prepareCPSubsystemConfig
+(defn prepare-cp-subsystem-config
   "Prepare Hazelcast CPSubsystemConfig"
   [config members]
   (let [cpSubsystemConfig (.getCPSubsystemConfig config)
         raftAlgorithmConfig (.getRaftAlgorithmConfig cpSubsystemConfig)
         semaphoreConfig (CPSemaphoreConfig. "jepsen.cpSemaphore" false)
         lockConfig1 (FencedLockConfig. "jepsen.cpLock1" 1)
-        lockConfig2 (FencedLockConfig. "jepsen.cpLock2" 2)
+        lockConfig2 (FencedLockConfig. "jepsen.cpLock2" 2)]
 
-        _ (.setLeaderElectionTimeoutInMillis raftAlgorithmConfig 1000)
-        _ (.setLeaderHeartbeatPeriodInMillis raftAlgorithmConfig 1500)
-        _ (.setCommitIndexAdvanceCountToSnapshot raftAlgorithmConfig 250)
-        _ (.setFailOnIndeterminateOperationState cpSubsystemConfig true)
+       (.setLeaderElectionTimeoutInMillis raftAlgorithmConfig 1000)
+       (.setLeaderHeartbeatPeriodInMillis raftAlgorithmConfig 1500)
+       (.setCommitIndexAdvanceCountToSnapshot raftAlgorithmConfig 250)
+       (.setFailOnIndeterminateOperationState cpSubsystemConfig true)
 
-        _ (.setCPMemberCount cpSubsystemConfig (count members))
-        _ (.setSessionHeartbeatIntervalSeconds cpSubsystemConfig 5)
-        _ (.setSessionTimeToLiveSeconds cpSubsystemConfig 300)
+       (.setCPMemberCount cpSubsystemConfig (count members))
+       (.setSessionHeartbeatIntervalSeconds cpSubsystemConfig 5)
+       (.setSessionTimeToLiveSeconds cpSubsystemConfig 300)
 
-        _ (.addSemaphoreConfig cpSubsystemConfig semaphoreConfig)
-        _ (.addLockConfig cpSubsystemConfig lockConfig1)
-        _ (.addLockConfig cpSubsystemConfig lockConfig2)
-
-      ]
-    cpSubsystemConfig))
+       (.addSemaphoreConfig cpSubsystemConfig semaphoreConfig)
+       (.addLockConfig cpSubsystemConfig lockConfig1)
+       (.addLockConfig cpSubsystemConfig lockConfig2)
+       cpSubsystemConfig))
 
 (defn -main
   "Go go go"
@@ -70,7 +68,7 @@
         _       (.setEnabled tcp-ip true)
 
         ; prepare the CP subsystem
-        _ (prepareCPSubsystemConfig config members)
+        _ (prepare-cp-subsystem-config config members)
 
         ; Quorum for split-brain protection
         quorum (doto (QuorumConfig.)

--- a/hazelcast/src/jepsen/hazelcast.clj
+++ b/hazelcast/src/jepsen/hazelcast.clj
@@ -7,17 +7,17 @@
             [clojure.string :as str]
             [knossos.model :as model]
             [jepsen [checker :as checker]
-                    [cli :as cli]
-                    [client :as client]
-                    [core :as jepsen]
-                    [control :as c]
-                    [db :as db]
-                    [generator :as gen]
-                    [independent :as independent]
-                    [nemesis :as nemesis]
-                    [tests :as tests]
-                    [reconnect :as rc]
-                    [util :as util :refer [timeout]]]
+             [cli :as cli]
+             [client :as client]
+             [core :as jepsen]
+             [control :as c]
+             [db :as db]
+             [generator :as gen]
+             [independent :as independent]
+             [nemesis :as nemesis]
+             [tests :as tests]
+             [reconnect :as rc]
+             [util :as util :refer [timeout]]]
             [jepsen.checker.timeline :as timeline]
             [jepsen.control.util :as cu]
             [jepsen.control.net :as cn]
@@ -26,8 +26,10 @@
            (com.hazelcast.client.config ClientConfig)
            (com.hazelcast.client HazelcastClient)
            (com.hazelcast.core HazelcastInstance)
-           (com.hazelcast.core IMap)
-           (com.hazelcast.spi.discovery NodeFilter)))
+           (knossos.model Model)
+           (java.util UUID)
+           (java.io IOException)
+           (com.hazelcast.quorum QuorumException)))
 
 (def local-server-dir
   "Relative path to local server project directory"
@@ -48,38 +50,44 @@
 (def pid-file (str dir "/server.pid"))
 (def log-file (str dir "/server.log"))
 
+(def CLIENT_ID_SEPARATOR "xxxxxxxxxx")
+(def REENTRANT_LOCK_ACQUIRE_COUNT 2)
+(def NUMBER_OF_PERMITS 2)
+(def LOGGING_SLEEP_DURATION_MS 1000)
+(def INVALID_FENCE 0)
+
 (defn build-server!
   "Ensures the server jar is ready"
   [test node]
   (when (= node (jepsen/primary test))
     (when-not (.exists (io/file local-server-jar))
-      (info "Building server")
-      (let [{:keys [exit out err]} (sh "lein" "uberjar" :dir "server")]
-        (info out)
-        (info err)
-        (info exit)
-        (assert (zero? exit))))))
+    (info "Building server")
+    (let [{:keys [exit out err]} (sh "lein" "uberjar" :dir "server")]
+      (info out)
+      (info err)
+      (info exit)
+      (assert (zero? exit)))))
+ )
 
 (defn install!
   "Installs the server on remote nodes."
   []
   (c/cd dir
-    (c/exec :mkdir :-p dir)
-    (c/upload (.getCanonicalPath (io/file local-server-jar))
-              jar)))
+        (c/exec :mkdir :-p dir)
+        (c/upload (.getCanonicalPath (io/file local-server-jar))
+                  jar)))
 
 (defn start!
   "Launch hazelcast server"
   [test node]
   (c/cd dir
         (cu/start-daemon!
-          {:chdir dir
+          {:chdir   dir
            :logfile log-file
            :pidfile pid-file}
           "/usr/bin/java"
           :-jar jar
           :--members (->> (:nodes test)
-                          (remove #{node})
                           (map cn/ip)
                           (str/join ",")))))
 
@@ -119,37 +127,25 @@
         _ (.setProperty config "hazelcast.client.heartbeat.interval" "1000")
         _ (.setProperty config "hazelcast.client.heartbeat.timeout" "5000")
         _ (.setProperty config "hazelcast.client.invocation.timeout.seconds" "5")
-        _ (.setProperty config "hazelcast.heartbeat.interval.seconds" "1")
-        _ (.setProperty config "hazelcast.master.confirmation.interval.seconds" "1")
-        _ (.setProperty config "hazelcast.max.no.heartbeat.seconds" "5")
-        _ (.setProperty config "hazelcast.max.no.master.confirmation.seconds" "10")
-        _ (.setProperty config "hazelcast.operation.call.timeout.millis" "5000")
+        _ (.setInstanceName config node)
 
-        net    (doto (.getNetworkConfig config)
-                 ; Don't retry operations when network fails (!?)
-                 (.setRedoOperation false)
-                 ; Timeouts
-                 (.setConnectionTimeout 5000)
-                 ; Initial connection limits
-                 (.setConnectionAttemptPeriod 1000)
-                 ; Try reconnecting indefinitely
-                 (.setConnectionAttemptLimit 0)
-                 ; Don't use a local cache of the partition map
-                 (.setSmartRouting false))
-        _      (info :net net)
+        net (doto (.getNetworkConfig config)
+              ; Don't retry operations when network fails (!?)
+              (.setRedoOperation false)
+              ; Timeouts
+              (.setConnectionTimeout 5000)
+              ; Initial connection limits
+              (.setConnectionAttemptPeriod 1000)
+              ; Try reconnecting indefinitely
+              (.setConnectionAttemptLimit 0)
+              ; Don't use a local cache of the partition map
+              (.setSmartRouting false))
+        _ (info :net net)
         ; Only talk to our node (the client's smart and will try to talk to
         ; everyone, but we're trying to simulate clients in different network
         ; components here)
-        node-filter (reify NodeFilter
-                      (test [this candidate]
-                        (prn node :testing candidate)
-                        (info node :testing candidate)
-                        true))
-        _      (.. net
-                   getDiscoveryConfig
-                   (setNodeFilter node-filter))
         ; Connect to our node
-        _      (.addAddress net (into-array String [node]))]
+        _ (.addAddress net (into-array String [node]))]
     (HazelcastClient/newHazelcastClient config)))
 
 (defn atomic-long-id-client
@@ -166,7 +162,83 @@
       (assoc op :type :ok, :value (.incrementAndGet atomic-long)))
 
     (teardown! [this test]
-      (.terminate conn))))
+      (.shutdown conn))))
+
+
+(defn create-cp-atomic-long
+  "Creates a new CP based AtomicLong"
+  [client name]
+  (.getAtomicLong (.getCPSubsystem client) name))
+
+
+(defn create-cp-atomic-reference
+  "Creates a new CP based AtomicReference"
+  [client name]
+  (.getAtomicReference (.getCPSubsystem client) name))
+
+
+(defn cp-atomic-long-id-client
+  "Generates unique IDs using a CP AtomicLong"
+  [conn atomic-long]
+  (reify client/Client
+    (setup! [_ test node]
+      (let [conn (connect node)]
+        (cp-atomic-long-id-client conn (create-cp-atomic-long conn "jepsen.atomic-long"))))
+
+    (invoke! [this test op]
+      (assert (= (:f op) :generate))
+      (assoc op :type :ok, :value (.incrementAndGet atomic-long)))
+
+    (teardown! [this test]
+      (.shutdown conn))))
+
+(defn cp-cas-long-client
+  "A CAS register using a CP AtomicLong"
+  [conn atomic-long]
+  (reify client/Client
+    (setup! [_ test node]
+      (let [conn (connect node)]
+        (cp-cas-long-client conn (create-cp-atomic-long conn "jepsen.cas-long"))))
+
+    (invoke! [this test op]
+      (case (:f op)
+        :read (assoc op :type :ok, :value (.get atomic-long))
+        :write (do (.set atomic-long (:value op))
+                   (assoc op :type :ok))
+        :cas (let [[currentV newV] (:value op)]
+               (if (.compareAndSet atomic-long currentV newV)
+                 (assoc op :type :ok)
+                 (assoc op :type :fail :error :cas-failed)
+                 ))
+        )
+      )
+
+    (teardown! [this test]
+      (.shutdown conn))))
+
+(defn cp-cas-reference-client
+  "A CAS register using a CP AtomicReference"
+  [conn atomic-ref]
+  (reify client/Client
+    (setup! [_ test node]
+      (let [conn (connect node)]
+        (cp-cas-reference-client conn (create-cp-atomic-reference conn "jepsen.cas-register"))))
+
+    (invoke! [this test op]
+      (case (:f op)
+        :read (assoc op :type :ok, :value (.get atomic-ref))
+        :write (do (.set atomic-ref (:value op))
+                   (assoc op :type :ok))
+        :cas (let [[currentV newV] (:value op)]
+               (if (.compareAndSet atomic-ref currentV newV)
+                 (assoc op :type :ok)
+                 (assoc op :type :fail :error :cas-failed)
+                 ))
+        )
+      )
+
+    (teardown! [this test]
+      (.shutdown conn))))
 
 (defn atomic-ref-id-client
   "Generates unique IDs using an AtomicReference"
@@ -186,7 +258,7 @@
           (assoc op :type :fail, :error :cas-failed))))
 
     (teardown! [this test]
-      (.terminate conn))))
+      (.shutdown conn))))
 
 (defn id-gen-id-client
   "Generates unique IDs using an IdGenerator"
@@ -202,7 +274,7 @@
       (assoc op :type :ok, :value (.newId id-gen)))
 
     (teardown! [this test]
-      (.terminate conn))))
+      (.shutdown conn))))
 
 (def queue-poll-timeout
   "How long to wait for items to become available in the queue, in ms"
@@ -224,17 +296,17 @@
          :enqueue (do (.put queue (:value op))
                       (assoc op :type :ok))
          :dequeue (if-let [v (.poll queue
-                                 queue-poll-timeout TimeUnit/MILLISECONDS)]
+                                    queue-poll-timeout TimeUnit/MILLISECONDS)]
                     (assoc op :type :ok, :value v)
                     (assoc op :type :fail, :error :empty))
-         :drain   (loop [values []]
-                    (if-let [v (.poll queue
-                                      queue-poll-timeout TimeUnit/MILLISECONDS)]
-                      (recur (conj values v))
-                      (assoc op :type :ok, :value values)))))
+         :drain (loop [values []]
+                  (if-let [v (.poll queue
+                                    queue-poll-timeout TimeUnit/MILLISECONDS)]
+                    (recur (conj values v))
+                    (assoc op :type :ok, :value values)))))
 
      (teardown! [this test]
-       (.terminate conn)))))
+       (.shutdown conn)))))
 
 (defn queue-gen
   "A generator for queue operations. Emits enqueues of sequential integers."
@@ -257,55 +329,235 @@
                          gen/once
                          gen/each)})
 
-(defn lock-client
-  ([] (lock-client nil nil))
-  ([conn lock-name]
+(defn log-acquire-ok
+  [clientName op]
+  (do
+    (try (Thread/sleep LOGGING_SLEEP_DURATION_MS) (catch Exception _))
+    (info (str "_" clientName "_acquire_ok " (:value op)))))
+
+(defn log-acquire-fail
+  [clientName op]
+  (do
+    (try (Thread/sleep LOGGING_SLEEP_DURATION_MS) (catch Exception _))
+    (info (str "_" clientName "_acquire_fail " (:value op)))))
+
+(defn log-acquire-maybe
+  [clientName op exception]
+  (do
+    (try (Thread/sleep LOGGING_SLEEP_DURATION_MS) (catch Exception _))
+    (info (str "_" clientName "_acquire_maybe " (:value op) " exception: " (.getMessage exception)))))
+
+(defn log-release-ok
+  [clientName op]
+  (do
+    (try (Thread/sleep LOGGING_SLEEP_DURATION_MS) (catch Exception _))
+    (info (str "_" clientName "_release_ok " (:value op)))))
+
+(defn log-release-fail
+  [clientName op]
+  (do
+    (try (Thread/sleep LOGGING_SLEEP_DURATION_MS) (catch Exception _))
+    (info (str "_" clientName "_release_fail " (:value op)))))
+
+(defn log-release-maybe
+  [clientName op exception]
+  (do
+    (try (Thread/sleep LOGGING_SLEEP_DURATION_MS) (catch Exception _))
+    (info (str "_" clientName "_release_maybe " (:value op) " exception: " (.getMessage exception)))))
+
+(defn invoke-acquire [clientName lock op]
+  (let [fence (.tryLockAndGetFence lock 5000 TimeUnit/MILLISECONDS)]
+    (if (not= fence INVALID_FENCE)
+      (do
+        (log-acquire-ok clientName op)
+        (assoc op :type :ok :value {:client clientName :fence fence :uid (:value op)})
+        )
+      (do
+        (log-acquire-fail clientName op)
+        (assoc op :type :fail)
+        )
+      )
+    )
+  )
+
+(defn fenced-lock-client
+  ([lock-name] (fenced-lock-client nil nil lock-name))
+  ([conn lock lock-name]
    (reify client/Client
      (setup! [_ test node]
-       (let [conn (rc/open! (rc/wrapper {:name  "hazelcast"
-                                         :open  #(connect node)
-                                         :close #(.terminate %)
-                                         :log?  true}))]
-         (lock-client conn "jepsen.lock")))
+       (let [conn (connect node)]
+         (fenced-lock-client conn (.getLock (.getCPSubsystem conn) lock-name) lock-name)
+         )
+       )
+
+     (invoke! [this test op]
+       (let [clientName (.getName conn)]
+         (try
+           (info (str " " CLIENT_ID_SEPARATOR " " clientName " " CLIENT_ID_SEPARATOR " " op))
+           (case (:f op)
+             :acquire (invoke-acquire clientName lock op)
+             :release (do
+                        (.unlock lock)
+                        (log-release-ok clientName op)
+                        (assoc op :type :ok :value {:client clientName :uid (:value op)})
+                        )
+             )
+           (catch IllegalMonitorStateException e
+             (case (:f op) :acquire (log-acquire-fail clientName op) :release (log-release-fail clientName op))
+             (assoc op :type :fail, :error :not-lock-owner)
+             )
+           (catch IOException e
+             (condp re-find (.getMessage e)
+               ; This indicates that the Hazelcast client doesn't have a remote
+               ; peer available, and that the message was never sent.
+               #"Packet is not send to owner address"
+               (do
+                 (case (:f op) :acquire (log-acquire-fail clientName op) :release (log-release-fail clientName op))
+                 (assoc op :type :fail, :error :client-down)
+                 )
+               (do
+                 (case (:f op) :acquire (log-acquire-maybe clientName op e) :release (log-release-maybe clientName op e))
+                 (assoc op :type :info, :error :io-exception)
+                 )
+               )
+             )
+           (catch Exception e
+             (case (:f op) :acquire (log-acquire-maybe clientName op e) :release (log-release-maybe clientName op e))
+             (assoc op :type :info, :error :exception)
+             )
+           )
+         )
+       )
+
+     (teardown! [this test]
+       (try
+         (.terminate (.getLifecycleService conn))
+         (catch Exception e
+           (warn "exception while client termination")
+           (.printStackTrace e)
+           )
+         )
+       )
+
+     )
+    )
+  )
+
+(defn cp-semaphore-client
+  ([] (cp-semaphore-client nil nil))
+  ([conn semaphore]
+   (reify client/Client
+     (setup! [_ test node]
+       (let [conn (connect node)
+             sem (.getSemaphore (.getCPSubsystem conn) "jepsen.cpSemaphore")
+             _ (.init sem NUMBER_OF_PERMITS)]
+         (cp-semaphore-client conn sem)
+         )
+       )
+
+     (invoke! [this test op]
+       (let [clientName (.getName conn)]
+         (try
+           (info (str " " CLIENT_ID_SEPARATOR " " clientName " " CLIENT_ID_SEPARATOR " " op))
+           (case (:f op)
+             :acquire (if (.tryAcquire semaphore 5000 TimeUnit/MILLISECONDS)
+                        (do
+                          (log-acquire-ok clientName op)
+                          (assoc op :type :ok :value {:client clientName :uid (:value op)})
+                          )
+                        (do
+                          (log-acquire-fail clientName op)
+                          (assoc op :type :fail :debug {:client clientName :uid (:value op)}))
+                        )
+             :release (do
+                        (.release semaphore)
+                        (log-release-ok clientName op)
+                        (assoc op :type :ok :value {:client clientName :uid (:value op)})
+                        )
+             )
+           (catch IllegalArgumentException e
+             (case (:f op) :acquire (log-acquire-fail clientName op) :release (log-release-fail clientName op))
+             (assoc op :type :fail :error :not-permit-owner :debug {:client clientName :uid (:value op)})
+             )
+           (catch IOException e
+             (condp re-find (.getMessage e)
+               ; This indicates that the Hazelcast client doesn't have a remote
+               ; peer available, and that the message was never sent.
+               #"Packet is not send to owner address"
+               (do
+                 (case (:f op) :acquire (log-acquire-fail clientName op) :release (log-release-fail clientName op))
+                 (assoc op :type :fail :error :client-down :debug {:client clientName :uid (:value op)})
+                 )
+               (do
+                 (case (:f op) :acquire (log-acquire-maybe clientName op e) :release (log-release-maybe clientName op e))
+                 (assoc op :type :info :error :io-exception :debug {:client clientName :uid (:value op)}))
+               )
+             )
+           (catch Exception e
+             (case (:f op) :acquire (log-acquire-maybe clientName op e) :release (log-release-maybe clientName op e))
+             (assoc op :type :info :error :exception :debug {:client clientName :uid (:value op)})
+             )
+           )
+         )
+       )
+
+     (teardown! [this test]
+       (try
+         (.terminate (.getLifecycleService conn))
+         (catch Exception e
+           (warn "exception while client termination")
+           (.printStackTrace e)
+           )
+         )
+       )
+
+     )
+    )
+  )
+
+(defn lock-client
+  ([lock-name] (lock-client nil nil lock-name))
+  ([conn lock lock-name]
+   (reify client/Client
+     (setup! [_ test node]
+       (let [conn (connect node)]
+         (lock-client conn (.getLock conn lock-name) lock-name)))
 
      (invoke! [this test op]
        (try
-         (rc/with-conn [c conn]
-           (let [lock (.getLock c lock-name)]
-             (case (:f op)
-               :acquire (if (.tryLock lock 5000 TimeUnit/MILLISECONDS)
-                          (assoc op :type :ok)
-                          (assoc op :type :fail))
-               :release (do (.unlock lock)
-                            (assoc op :type :ok)))))
-        (catch com.hazelcast.quorum.QuorumException e
-          (Thread/sleep 1000)
-          (assoc op :type :fail, :error :quorum))
-        (catch java.lang.IllegalMonitorStateException e
-          (Thread/sleep 1000)
-          (if (re-find #"Current thread is not owner of the lock!"
-                       (.getMessage e))
-            (assoc op :type :fail, :error :not-lock-owner)
-            (throw e)))
-        (catch java.io.IOException e
-          (Thread/sleep 1000)
-          (condp re-find (.getMessage e)
-            ; This indicates that the Hazelcast client doesn't have a remote
-            ; peer available, and that the message was never sent.
-            #"Packet is not send to owner address"
-            (assoc op :type :fail, :error :client-down)
+         (case (:f op)
+           :acquire (if (.tryLock lock 5000 TimeUnit/MILLISECONDS)
+                      (assoc op :type :ok)
+                      (assoc op :type :fail))
+           :release (do (.unlock lock)
+                        (assoc op :type :ok)))
+         (catch QuorumException e
+           (Thread/sleep 1000)
+           (assoc op :type :fail, :error :quorum))
+         (catch IllegalMonitorStateException e
+           (Thread/sleep 1000)
+           (if (re-find #"Current thread is not owner of the lock!"
+                        (.getMessage e))
+             (assoc op :type :fail, :error :not-lock-owner)
+             (throw e)))
+         (catch IOException e
+           (Thread/sleep 1000)
+           (condp re-find (.getMessage e)
+             ; This indicates that the Hazelcast client doesn't have a remote
+             ; peer available, and that the message was never sent.
+             #"Packet is not send to owner address"
+             (assoc op :type :fail, :error :client-down)
 
-            (throw e)))))
+             (throw e)))))
 
      (teardown! [this test]
-       (.terminate conn)))))
+       (.shutdown conn)))))
 
 (def map-name "jepsen.map")
 (def crdt-map-name "jepsen.crdt-map")
 
 (defn map-client
   "Options:
-
     :crdt? - If true, use CRDTs for merging divergent maps."
   ([opts] (map-client nil nil opts))
   ([conn m opts]
@@ -325,7 +577,7 @@
          ; arrays instead.
          :add (if-let [v (.get m "hi")]
                 ; We have a current set.
-                (let [s  (into (sorted-set) v)
+                (let [s (into (sorted-set) v)
                       s' (conj s (:value op))
                       v' (long-array s')]
                   (if (.replace m "hi" v v')
@@ -343,22 +595,209 @@
          :read (assoc op :type :ok, :value (into (sorted-set) (.get m "hi")))))
 
      (teardown! [this test]
-       (.terminate conn)))))
+       (.shutdown conn)))))
 
 (defn map-workload
   "A workload for map tests, with the given client options."
   [client-opts]
-  {:client    (map-client client-opts)
-   :generator (->> (range)
-                   (map (fn [x] {:type  :invoke
-                                 :f     :add
-                                 :value x}))
-                   gen/seq
-                   (gen/stagger 1/10))
+  {:client          (map-client client-opts)
+   :generator       (->> (range)
+                         (map (fn [x] {:type  :invoke
+                                       :f     :add
+                                       :value x}))
+                         gen/seq
+                         (gen/stagger 1/10))
    :final-generator (->> {:type :invoke, :f :read}
                          gen/once
                          gen/each)
-   :checker   (checker/set)})
+   :checker         (checker/set)})
+
+
+
+(defn parseLine [line]
+  (let
+    [tokens (.split line CLIENT_ID_SEPARATOR)]
+    [(:value (clojure.edn/read-string (nth tokens 2))) (.trim (nth tokens 1))]))
+
+(def clientUidsToClientNames (memoize (fn []
+                            (apply array-map
+                                   (flatten
+                                     (map parseLine
+                                          (.split (:out (sh "grep" CLIENT_ID_SEPARATOR "store/latest/jepsen.log")) "\n")
+                                          ))))))
+
+(defn getClient [op]
+  (let [val (:value op)]
+    (if (map? val) (:client val) (get (clientUidsToClientNames) (:value op)))))
+
+(defrecord ReentrantMutex [owner lockCount]
+  Model
+  (step [this op]
+    (let [client (getClient op)]
+      (if (nil? client)
+        (do
+          (info "no owner!")
+          (knossos.model/inconsistent "no owner!")
+          )
+        (condp = (:f op)
+          :acquire (if (and (< lockCount REENTRANT_LOCK_ACQUIRE_COUNT) (or (nil? owner) (= owner client)))
+                     (ReentrantMutex. client (+ lockCount 1))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     )
+          :release (if (or (nil? owner) (not= owner client))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     (ReentrantMutex. (if (= lockCount 1) nil owner) (- lockCount 1))
+                     )
+          )
+        )
+      )
+    )
+
+  Object
+  (toString [this] (str "owner: " owner ", lockCount: " lockCount)))
+
+(defn createReentrantMutex []
+  "A single reentrant mutex responding to :acquire and :release messages"
+  (ReentrantMutex. nil 0))
+
+
+
+(defrecord OwnerAwareMutex [owner]
+  Model
+  (step [this op]
+    (let [client (getClient op)]
+      (if (nil? client)
+        (do
+          (info "no owner!")
+          (knossos.model/inconsistent "no owner!")
+          )
+        (condp = (:f op)
+          :acquire (if (nil? owner)
+                     (OwnerAwareMutex. client)
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     )
+          :release (if (or (nil? owner) (not= owner client))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     (OwnerAwareMutex. nil)
+                     )
+          )
+        )
+      )
+    )
+
+  Object
+  (toString [this] (str "owner: " owner)))
+
+(defn createOwnerAwareMutex []
+  "A single non-reentrant mutex responding to :acquire and :release messages and tracking mutex owner"
+  (OwnerAwareMutex. nil))
+
+
+
+(defn getFence [op]
+  (let [val (:value op)]
+    (if (map? val) (:fence val) INVALID_FENCE)))
+
+(defrecord FencedMutex [owner lockFence prevOwner]
+  Model
+  (step [this op]
+    (let [client (getClient op) fence (getFence op)]
+      (if (nil? client)
+        (do
+          (info "no owner!")
+          (knossos.model/inconsistent "no owner!")
+          )
+        (condp = (:f op)
+          :acquire (cond
+                     (some? owner) (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     (= fence INVALID_FENCE) (FencedMutex. client lockFence owner)
+                     (> fence lockFence) (FencedMutex. client fence owner)
+                     :else (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     )
+          :release (if (or (nil? owner) (not= owner client))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     (FencedMutex. nil lockFence owner)
+                     )
+          )
+        )
+      )
+    )
+
+  Object
+  (toString [this] (str "owner: " owner " lock fence: " lockFence " prev owner: " prevOwner)))
+
+(defn createFencedMutex []
+  "A fenced mutex responding to :acquire and :release messages and tracking monotonicity of observed fences"
+  (FencedMutex. nil INVALID_FENCE nil))
+
+
+
+(defrecord ReentrantFencedMutex [owner lockCount currentFence highestObservedFence highestObservedFenceOwner]
+  Model
+  (step [this op]
+    (let [client (getClient op) fence (getFence op)]
+      (if (nil? client)
+        (do
+          (info "no owner!")
+          (knossos.model/inconsistent "no owner!")
+          )
+        (condp = (:f op)
+          :acquire (cond
+                     ; if the lock is not held
+                     (nil? owner)
+                      (cond
+                        ; I can have an invalid fence or a fence larger than highestObservedFence
+                        (or (= fence INVALID_FENCE) (> fence highestObservedFence))
+                        (ReentrantFencedMutex. client 1 fence (max fence highestObservedFence) highestObservedFenceOwner)
+                        :else
+                        (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                      )
+                     ; if the new acquire does not match to the current lock owner, or the lock is already acquired twice, we cannot acquire anymore
+                     (or (not= owner client) (= lockCount REENTRANT_LOCK_ACQUIRE_COUNT)) (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     ; if the lock is acquired without a fence, and the new acquire has no fence or a fence larger than highestObservedFence
+                     (= currentFence INVALID_FENCE) (cond (or (= fence INVALID_FENCE) (> fence highestObservedFence))
+                                                      (ReentrantFencedMutex. client 2 fence (max fence highestObservedFence) highestObservedFenceOwner)
+                                                    :else
+                                                      (knossos.model/inconsistent (str "client: " client " cannot " op " on " this)))
+                     ; if the lock is acquired with a fence, and the new acquire has no fence or the same fence
+                     (or (= fence INVALID_FENCE) (= fence currentFence)) (ReentrantFencedMutex. client 2 currentFence highestObservedFence highestObservedFenceOwner)
+                     :else (knossos.model/inconsistent (str "client: " client " cannot " op " on " this)))
+          :release (if (or (nil? owner) (not= owner client))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this))
+                     (cond (= lockCount 1) (ReentrantFencedMutex. nil 0 INVALID_FENCE highestObservedFence owner)
+                           :else (ReentrantFencedMutex. owner 1 currentFence highestObservedFence highestObservedFenceOwner)))))))
+
+  Object
+  (toString [this] (str "owner: " owner " lock count: " lockCount " lock fence: " currentFence " highest observed fence: " highestObservedFence " highest observed fence owner: " highestObservedFenceOwner)))
+
+(defn createReentrantFencedMutex []
+  "A reentrant fenced mutex responding to :acquire and :release messages and tracking monotonicity of observed fences"
+  (ReentrantFencedMutex. nil 0 INVALID_FENCE INVALID_FENCE nil))
+
+
+
+(defrecord AcquiredPermitsModel [acquired]
+  Model
+  (step [this op]
+    (let [client (getClient op)]
+      (if (nil? client)
+        (do
+          (info "no owner!")
+          (knossos.model/inconsistent "no owner!"))
+        (condp = (:f op)
+          :acquire (if (< (reduce + (vals acquired)) NUMBER_OF_PERMITS)
+                     (AcquiredPermitsModel. (assoc acquired client (+ (get acquired client) 1)))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this)))
+          :release (if (> (get acquired client) 0)
+                     (AcquiredPermitsModel. (assoc acquired client (- (get acquired client) 1)))
+                     (knossos.model/inconsistent (str "client: " client " cannot " op " on " this)))))))
+
+  Object
+  (toString [this] (str "acquired: " acquired)))
+
+(defn createAcquiredPermitsModel []
+  "A model that assign permits to multiple nodes via :acquire and :release messages"
+  (AcquiredPermitsModel. {"n1" 0 "n2" 0 "n3" 0 "n4" 0 "n5" 0}))
 
 
 (defn workloads
@@ -374,29 +813,110 @@
   this is a function, instead of a constant--we may need a fresh workload if we
   run more than one test."
   []
-  {:crdt-map         (map-workload {:crdt? true})
-   :map              (map-workload {:crdt? false})
-   :lock             {:client    (lock-client)
-                      :generator (->> [{:type :invoke, :f :acquire}
-                                       {:type :invoke, :f :release}]
-                                      cycle
-                                      gen/seq
-                                      gen/each)
-                      :checker   (checker/linearizable)
-                      :model     (model/mutex)}
-   :queue            (assoc (queue-client-and-gens)
-                            :checker (checker/total-queue))
-   :atomic-ref-ids   {:client (atomic-ref-id-client nil nil)
-                      :generator (->> {:type :invoke, :f :generate}
-                                      (gen/stagger 1))
-                      :checker  (checker/unique-ids)}
-   :atomic-long-ids  {:client (atomic-long-id-client nil nil)
-                      :generator (->> {:type :invoke, :f :generate}
-                                      (gen/stagger 1))
-                      :checker  (checker/unique-ids)}
-   :id-gen-ids       {:client    (id-gen-id-client nil nil)
-                      :generator {:type :invoke, :f :generate}
-                      :checker   (checker/unique-ids)}})
+  {:crdt-map                     (map-workload {:crdt? true})
+   :map                          (map-workload {:crdt? false})
+   :lock                         {:client    (lock-client "jepsen.lock")
+                                  :generator (->> [{:type :invoke, :f :acquire}
+                                                   {:type :invoke, :f :release}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (model/mutex)}
+   :lock-no-quorum               {:client    (lock-client "jepsen.lock.no-quorum")
+                                  :generator (->> [{:type :invoke, :f :acquire}
+                                                   {:type :invoke, :f :release}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (model/mutex)}
+   :non-reentrant-cp-lock        {:client    (fenced-lock-client "jepsen.cpLock1")
+                                  :generator (->> [{:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (createOwnerAwareMutex)}
+   :reentrant-cp-lock            {:client    (fenced-lock-client "jepsen.cpLock2")
+                                  :generator (->> [{:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (createReentrantMutex)}
+   :non-reentrant-fenced-lock    {:client    (fenced-lock-client "jepsen.cpLock1")
+                                  :generator (->> [{:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (createFencedMutex)}
+   :reentrant-fenced-lock        {:client    (fenced-lock-client "jepsen.cpLock2")
+                                  :generator (->> [{:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (createReentrantFencedMutex)}
+   :cp-semaphore {:client        (cp-semaphore-client)
+                                  :generator (->> [{:type :invoke, :f :acquire :value (.toString (UUID/randomUUID))}
+                                                   {:type :invoke, :f :release :value (.toString (UUID/randomUUID))}]
+                                                  cycle
+                                                  gen/seq
+                                                  gen/each
+                                                  (gen/stagger 1/10))
+                                  :checker   (checker/linearizable)
+                                  :model     (createAcquiredPermitsModel)}
+   :cp-id-gen-long               {:client    (cp-atomic-long-id-client nil nil)
+                                  :generator (->> {:type :invoke, :f :generate}
+                                                (gen/stagger 0.5))
+                                  :checker   (checker/unique-ids)}
+   :cp-cas-long                  {:client    (cp-cas-long-client nil nil)
+                                  :generator (->> (gen/mix [{:type :invoke, :f :read}
+                                                            {:type :invoke, :f :write, :value (rand-int 5)}
+                                                            (gen/sleep 1)
+                                                            {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]}])
+                                                gen/each
+                                                (gen/stagger 0.5))
+                                  :checker   (checker/linearizable)
+                                  :model     (model/cas-register 0)}
+   :cp-cas-reference             {:client    (cp-cas-reference-client nil nil)
+                                  :generator (->> (gen/mix [{:type :invoke, :f :read}
+                                                            {:type :invoke, :f :write, :value (rand-int 5)}
+                                                            (gen/sleep 1)
+                                                            {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]}])
+                                                  gen/each
+                                                  (gen/stagger 0.5))
+                                  :checker   (checker/linearizable)
+                                  :model     (model/cas-register 0)}
+   :queue                        (assoc (queue-client-and-gens)
+                                   :checker (checker/total-queue))
+   :atomic-ref-ids               {:client    (atomic-ref-id-client nil nil)
+                                  :generator (->> {:type :invoke, :f :generate}
+                                                  (gen/stagger 0.5))
+                                  :checker   (checker/unique-ids)}
+   :atomic-long-ids              {:client    (atomic-long-id-client nil nil)
+                                  :generator (->> {:type :invoke, :f :generate}
+                                                  (gen/stagger 0.5))
+                                  :checker   (checker/unique-ids)}
+   :id-gen-ids                   {:client    (id-gen-id-client nil nil)
+                                  :generator {:type :invoke, :f :generate}
+                                  :checker   (checker/unique-ids)}})
 
 (defn hazelcast-test
   "Constructs a Jepsen test map from CLI options"
@@ -407,7 +927,7 @@
                 checker
                 model]} (get (workloads) (:workload opts))
         generator (->> generator
-                       (gen/nemesis (gen/start-stop 30 15))
+                       (gen/nemesis (gen/start-stop 20 20))
                        (gen/time-limit (:time-limit opts)))
         generator (if-not final-generator
                     generator
@@ -420,29 +940,30 @@
                                 (gen/clients final-generator)))]
     (merge tests/noop-test
            opts
-           {:name       (str "hazelcast " (name (:workload opts)))
-            :os         debian/os
-            :db         (db)
-            :client     client
-            :nemesis    (nemesis/partition-majorities-ring)
-            :generator  generator
-            :checker    (checker/compose
-                          {:perf     (checker/perf)
-                           :timeline (timeline/html)
-                           :workload checker})
-            :model      model})))
+           {:name      (str "hazelcast " (name (:workload opts)))
+            :os        debian/os
+            :db        (db)
+            :client    client
+            :nemesis   (nemesis/partition-majorities-ring)
+            ;:nemesis    nemesis/noop
+            :generator generator
+            :checker   (checker/compose
+                         {:perf     (checker/perf)
+                          :timeline (timeline/html)
+                          :workload checker})
+            :model     model})))
 
 (def opt-spec
   "Additional command line options"
   [[nil "--workload WORKLOAD" "Test workload to run, e.g. atomic-long-ids."
     :parse-fn keyword
-    :missing  (str "--workload " (cli/one-of (workloads)))
+    :missing (str "--workload " (cli/one-of (workloads)))
     :validate [(workloads) (cli/one-of (workloads))]]])
 
 (defn -main
   "Command line runner."
   [& args]
-  (cli/run! (merge (cli/single-test-cmd {:test-fn   hazelcast-test
-                                         :opt-spec  opt-spec})
+  (cli/run! (merge (cli/single-test-cmd {:test-fn  hazelcast-test
+                                         :opt-spec opt-spec})
                    (cli/serve-cmd))
             args))


### PR DESCRIPTION
CP Subsystem contains linearizable & distributed implementations of the java.util.concurrent APIs offered by Hazelcast. We have been testing it with a new test suite we wrote while developing the new system. We would like to submit these tests to the official Jepsen repo.

Javadoc for the CP Subsystem: https://docs.hazelcast.org/docs/3.12-BETA-1/javadoc/com/hazelcast/cp/CPSubsystem.html

Reference Manual for the CP Subsystem: https://docs.hazelcast.org/docs/3.12-BETA-1/manual/html-single/index.html#cp-subsystem

Our CP subsystem test suite is as follows:

- Non-reentrant lock (`--workload non-reentrant-cp-lock`): In this test case, we test if the new `FencedLock` data structure behaves as a non-reentrant mutex, i.e., it can be held by a single endpoint at a time and only the lock holder endpoint can release it. Moreover, the lock cannot be acquired by the same endpoint reentrantly. It means that while a client holds the lock, it cannot acquire the lock again, without releasing the lock first.

- Reentrant lock (`--workload reentrant-cp-lock`): We test if the new `FencedLock` data structure behaves as a reentrant mutex. The lock instance can be held by a single endpoint at a time and only the lock holder endpoint can release it. Moreover, the current lock holder can reentrantly acquire the lock one more time. Reentrant lock acquire limit is 2 for this test.

- Non-reentrant fenced lock (`--workload non-reentrant-fenced-lock`): `FencedLock` orders lock holders by a monotonic fencing token, which is incremented each time the lock switches from the free state to the held state. In this test case, we validate monotonicity of fencing tokens assigned to subsequent lock holders. Moreover, the lock cannot be acquired by the same endpoint reentrantly. It means that while a client holds the lock, it cannot acquire the lock again, without releasing the lock first.

- Reentrant fenced lock (`--workload reentrant-fenced-lock`): `FencedLock` orders lock holders by a monotonic fencing token, which is incremented each time the lock switches from the free state to the held state. However, if the current lock holder acquires the lock reentrantly, it will get the same fencing token. Reentrant lock acquire limit is 2 for this test.

- Semaphore (`--workload semaphore`): In this test, we initialize our new linearizable `ISemaphore` with 2 permits. Each client acquires and releases a permit in a loop and we validate permits are held by at most 2 clients at a time.

- Unique ID Generation with the new linearizable `IAtomicLong` (`--workload cp-id-gen-long`): In this test, each client generates a unique long id by using a linearizable IAtomicLong instance and we validate uniqueness of generated ids.

- Compare-and-swap Register with the new linearizable `IAtomicLong` (`--workload cp-cas-long`): In this test, clients randomly perform write and compare-and-swap operations.

- Compare-and-swap Register with the new linearizable `IAtomicReference` (`--workload cp-cas-reference`): In this test, clients randomly perform write and compare-and-swap operations.

Please see the README file for more details.

We are happy to answer any questions related to the new impls and tests.

Thanks in advance for your review and happy testing!

Co-authored-by: Mehmet Dogan <mehmet@hazelcast.com>
Co-authored-by: Ensar Basri Kahveci <basri@hazelcast.com>