### PR TITLE
monotonic cycle test

### DIFF
--- a/jepsen/src/jepsen/tests/monotonic_cycle.clj
+++ b/jepsen/src/jepsen/tests/monotonic_cycle.clj
@@ -1,0 +1,104 @@
+(ns jepsen.tests.monotonic-cycle
+  "A checker which searches for incidents of read skew. Because each register
+  is increment-only, we know that there should never exist a pair of reads r1
+  and r2, such that for two registers x and y, where both registers are
+  observed by both reads, x_r1 < x_r2 and y_r1 > y_r2.
+
+  This problem is equivalent to cycle detection: we have a set of partial
+  orders <x, <y, ..., each of which relates states based on whether x increases
+  or not. We're trying to determine whether these orders are *compatible*.
+
+  Imagine an order <x as a graph over states, and likewise for <y, <z, etc.
+  Take the union of these graphs. If all these orders are compatible, there
+  should be no cycles in this graph.
+
+  To do this, we take each key k, and find all values for k. In general, the
+  ordering relation <k is the transitive closure, but for cycle detection, we
+  don't actually need the full closure--we'll restrict ourselves to k=1's
+  successors being those with k=2 (or, if there are no k=2, use k=3, etc). This
+  gives us a set of directed edges over states for k; we union the graphs for
+  all k together to obtain a graph of all relationships.
+
+  Next, we apply Tarjan's algorithm for strongly connected components, which is
+  linear in edges + vertices (which is why we don't work with the full
+  transitive closure of <k). The existence of any strongly connected components
+  containing more than one vertex implies a cycle in the graph, and that cycle
+  will be within that component.
+
+  This isn't suuuper ideal... the connected component could, I guess, be fairly
+  large, and then it'd be hard to prove where the cycle lies. But this feels
+  like an OK start."
+  (:require [jepsen.checker :as checker]
+            [knossos.op :as op]
+            [clojure.core.reducers :as r]
+            [clojure.set :as set]))
+
+(defn tarjan
+  "Returns the strongly connected components of a graph specified by its nodes
+  and a successor function (next) succs from node to nodes. An implementation of
+  Tarjan's Strongly Connected Components.
+  From: http://clj-me.cgrand.net/2013/03/18/tarjans-strongly-connected-components-algorithm/"
+  [nodes succs]
+  ;; Env is a map from nodes to stack length or nil, nil means the node is
+  ;; known to belong to another SCC (Strongly Connected Component) :stack for
+  ;; the current stack and :sccs for the current set of SCCs.
+  (letfn [(sc [env node]
+            (if (contains? env node)
+              env
+              (let [stack (:stack env)
+                    n     (count stack)
+                    env   (assoc env node n :stack (conj stack node))
+                    env   (reduce (fn [env next]
+                                    (let [env (sc env next)]
+                                      (assoc env node (min (or (env next) n) (env node)))))
+                                  env (succs node))]
+                ;; No link below us in the stack, assign to SCCs
+                (if (= n (env node))
+                  (let [nodes (:stack env)
+                        scc (set (take (- (count nodes) n) nodes))
+                        ;; clear all stack lengths for these nodes since this SCC is done
+                        env (reduce #(assoc %1 %2 nil) env scc)]
+                    (assoc env :stack stack :sccs (conj (:sccs env) scc)))
+                  env))))]
+    (let [state  {:stack '() :sccs #{}}
+          result (reduce sc state nodes)]
+      (:sccs result))))
+
+(defn errors [history expected]
+  (let [;; Only looking at ok reads
+        f (fn [errors op]
+            (let [seen         (:value op)
+                  our-expected (->> seen
+                                    (map expected)
+                                    (reduce set/union))
+                  missing (set/difference our-expected
+                                          seen)]
+              ;; FIXME This is just the contents of causal reverse
+              (if (empty? missing)
+                errors
+                (conj errors
+                      (-> op
+                          (dissoc :value)
+                          (assoc :missing missing)
+                          (assoc :expected-count
+                                 (count our-expected)))))))]
+    (reduce f [] history)))
+
+(defn checker []
+  (reify checker/Checker
+    (check [this test history opts]
+      ;; TODO How many reads are we looking at at once?
+      (let [h (->> history
+                   (r/filter op/ok?)
+                   (r/filter #(= :read (:f %))))
+            graph []
+            errors (errors h graph)]
+
+        {:valid? (empty? errors)
+         :errors errors}))))
+
+(defn workload
+  []
+  {:checker (checker)
+   ;; TODO Gen
+   :generator []})

--- a/jepsen/src/jepsen/tests/monotonic_cycle.clj
+++ b/jepsen/src/jepsen/tests/monotonic_cycle.clj
@@ -73,17 +73,19 @@
   FIXME Handle multiple registers and transactions of reads"
   [history]
   (loop [graph {}
-         [op & more :as history] history
+         [{:keys [value]} & more :as history] history
          last nil]
-    (let [val  (:value op)
-          prev (if last
-                 {last #{val}}
-                 {})
-          next {val #{}}
-          g'   (merge-with set/union graph prev next)]
-      (if more
-        (recur g' more val)
-        g'))))
+    (if (= value last)
+      ;; If the new val is the same as the last, skip.
+      graph
+      (let [prev (if last
+                   {last #{value}}
+                   {})
+            next {value #{}}
+            g'   (merge-with set/union graph prev next)]
+        (if more
+          (recur g' more value)
+          g')))))
 
 ;; TODO Can we improve this error output?
 (defn errors

--- a/jepsen/src/jepsen/tests/monotonic_cycle.clj
+++ b/jepsen/src/jepsen/tests/monotonic_cycle.clj
@@ -64,25 +64,24 @@
           result (reduce sc state nodes)]
       (:sccs result))))
 
-(merge-with clojure.set/union {} {0 #{nil}} {1 #{0}})
-
 (defn graph
   "Takes a history of reads over a single register and returns a graph of the
   states that the register advanced through.
   FIXME Stack overflow on n>10000 histories
-  FIXME Handle multiple registers and transactions of reads"
+  FIXME Handle multiple registers and transactions of reads
+  FIXME This could probably be a reduction"
   [history]
   (loop [graph {}
-         [{:keys [value]} & more :as history] history
+         [{:keys [value]} & more] history
          last nil]
     (if (= value last)
       ;; If the new val is the same as the last, skip.
       graph
-      (let [prev (if last
+      (let [edge (if last
                    {last #{value}}
                    {})
-            next {value #{}}
-            g'   (merge-with set/union graph prev next)]
+            node {value #{}}
+            g'   (merge-with set/union graph edge node)]
         (if more
           (recur g' more value)
           g')))))
@@ -111,7 +110,7 @@
          :errors errors}))))
 
 (defn w [v] {:f :write, :type :invoke, :value v})
-(defn r [v] {:f :read,  :type :invoke})
+(defn r [] {:f :read, :type :invoke})
 
 (defn workload
   []

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -4,38 +4,110 @@
             [knossos.op :as op]
             [clojure.test :refer :all]))
 
-(def numeric-graph
-  {1 #{2},
-   2 #{3},
-   3 #{1},
-   4 #{2 3 5},
-   5 #{4 6},
-   6 #{3 7},
-   7 #{6},
-   8 #{7 8}})
-
-(def key-graph
-  {:a #{:b},
-   :b #{:c},
-   :c #{:a},
-   :d #{:b :c :e},
-   :e #{:d :f},
-   :f #{:c :g},
-   :g #{:f},
-   :h #{:f :h}})
-
 (deftest tarjan-test
-  (testing "Returns strongly connected components"
-    ;; Graph is taken from the wikipedia page
-    (is (= (tarjan (keys key-graph) key-graph)
-           #{#{:c :b :a} #{:g :f} #{:e :d} #{:h}}))))
+  (testing "Can analyze keyword graphs"
+    ;; Modeled after the example on the wikipedia page
+    (let [graph {:a #{:b}    :b #{:c}
+                 :c #{:a}    :d #{:b :c :e}
+                 :e #{:d :f} :f #{:c :g}
+                 :g #{:f}    :h #{:f :h}}]
+      (is (= (tarjan (keys graph) graph)
+              #{#{:c :b :a} #{:g :f} #{:e :d} #{:h}}))))
 
-(deftest cycle-test
-  (testing "Can flag cyclic reads"
-    (let [c (checker)
-          history [(op/invoke 0 :read nil)
-                   (op/ok     0 :read [0 1])
-                   (op/invoke 0 :read nil)
-                   (op/ok     0 :read [1 0])]
+  (testing "Can analyze integer graphs"
+    (let [graph {1 #{2}   2 #{3}
+                 3 #{1}   4 #{2 3 5}
+                 5 #{4 6} 6 #{3 7}
+                 7 #{6}   8 #{7 8}}]
+      (is (= (tarjan (keys graph) graph)
+             #{#{3 2 1} #{6 7} #{5 4} #{8}}))))
+
+  (testing "Can detect when the whole graph is strongly connected"
+    (let [graph {1 #{2} 2 #{3}
+                 3 #{4} 4 #{5}
+                 5 #{6} 6 #{7}
+                 7 #{8} 8 #{1}}]
+      (is (= (tarjan (keys graph) graph)
+             #{#{1 2 3 4 5 6 7 8}}))))
+
+  (testing "Can verify that no SCCs exist"
+    ;; A node with no strong connections is returned as a single-element set
+    (let [graph {1 #{} 2 #{} 3 #{} 4 #{}
+                 5 #{} 6 #{} 7 #{} 8 #{}}]
+      (is (= (tarjan (keys graph) graph)
+             #{#{1} #{2} #{3} #{4}
+               #{5} #{6} #{7} #{8}})))
+
+    ;; Self connections are equivalent to no connections in this impl.
+    (let [graph {1 #{1} 2 #{2} 3 #{3} 4 #{4}}]
+      (is (= (tarjan (keys graph) graph)
+             #{#{1} #{2} #{3} #{4}})))))
+
+(deftest graph-test
+  (testing "Can render a linear partial order"
+    (let [history [(op/ok     0 :read 0)
+                   (op/ok     0 :read 1)]]
+      (is (= (graph history)
+             {0 #{1} 1 #{}}))))
+
+  (testing "Can render a circular partial order"
+    (let [history [(op/ok     0 :read 0)
+                   (op/ok     0 :read 1)
+                   (op/ok     0 :read 0)]]
+      (is (= (graph history)
+             {0 #{1} 1 #{0}})))))
+
+(deftest errors-test
+  (testing "Flags lööps"
+    (let [graph {1 #{2} 2 #{1}}
+          components (tarjan (keys graph) graph)]
+      (is (= (errors components)
+             {#{1 2} true}))))
+
+  (testing "Doesn't flag lööpless"
+    (let [graph {1 #{1} 2 #{1}}
+          components (tarjan (keys graph) graph)]
+      (is (= (errors components)
+             {#{1} false
+              #{2} false})))))
+
+(defn big-history-gen
+  [v]
+  (let [f (rand-nth [:write :read])
+        proc (rand-int 100)
+        type (rand-nth [:ok :ok :ok :ok :ok
+                        :fail :info :info])]
+    [{:process proc, :type :invoke, :f f, :value v}
+     {:process proc, :type type,    :f f, :value v}]))
+
+(deftest checker-test
+  (testing "Can validate histories"
+    (let [checker   (checker)
+          history   [(op/invoke 0 :read nil)
+                     (op/ok     0 :read 0)
+                     (op/invoke 0 :write 1)
+                     (op/ok     0 :write 1)
+                     (op/invoke 0 :read nil)
+                     (op/ok     0 :read 1)]
           r (checker/check checker nil history nil)]
-      (is (not (:valid? r))))))
+      (is (:valid? r))))
+
+  (testing "Can invalidate histories"
+    (let [checker   (checker)
+          history   [(op/invoke 0 :read nil)
+                     (op/ok     0 :read 0)
+                     (op/invoke 0 :read nil)
+                     (op/ok     0 :read 1)
+                     (op/invoke 0 :read nil)
+                     (op/ok     0 :read 0)]
+          r (checker/check checker nil history nil)]
+      (is (not (:valid? r)))))
+
+  (testing "Can handle large histories"
+    (let [checker   (checker)
+          history   (->> (range)
+                         (mapcat big-history-gen)
+                         (take 10000)
+                         vec)
+          r (checker/check checker nil history nil)]
+      (is (:valid? r)))))

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -3,7 +3,8 @@
             [jepsen.checker :as checker]
             [jepsen.util :refer [map-vals]]
             [knossos.op :as op]
-            [clojure.test :refer :all]))
+            [clojure.test :refer :all]
+            [fipp.edn :as fipp]))
 
 (deftest tarjan-test
   (testing "Can analyze integer graphs"
@@ -62,98 +63,79 @@
       (is (= (tarjan graph)
              #{#{0}})))))
 
-(deftest graph-test
-  (testing "Can render a linear partial order"
-    (let [history [(op/ok 0 :read {:x 0})
-                   (op/ok 0 :read {:x 1})]]
-      (is (= (graph history)
-             {:x {0 #{1}
-                  1 #{}}}))))
+(deftest key-index-test
+  (testing "Can produce a key-index from a history"
+    (let [history [{:index 0 :type :ok, :f :read, :value {:x 0, :y 0}}
+                   {:index 2 :type :ok, :f :read, :value {:x 1, :y 0}}
+                   {:index 4 :type :ok, :f :read, :value {:x 1, :y 1}}
+                   {:index 5 :type :ok, :f :read, :value {:x 0, :y 1}}]
+          ki (reduce key-index (sorted-map) history)]
+      (is (= ki
+             {:x {0 #{0 5}
+                  1 #{2 4}}
+              :y {0 #{0 2}
+                  1 #{4 5}}})))))
 
-  (testing "Can render a circular partial order"
-    (let [history [(op/ok 0 :read {:x 0})
-                   (op/ok 0 :read {:x 1})
-                   (op/ok 0 :read {:x 0})]]
-      (is (= (graph history)
-             {:x {0 #{1}
-                  1 #{0}}}))))
+(deftest key-orders-test
+  (testing "Can produce a map of keys to their successors"
+    (let [history [{:index 0 :type :ok, :f :read, :value {:x 0, :y 0}}
+                   {:index 2 :type :ok, :f :read, :value {:x 1, :y 0}}
+                   {:index 4 :type :ok, :f :read, :value {:x 1, :y 1}}
+                   {:index 5 :type :ok, :f :read, :value {:x 0, :y 1}}]
+          ki {:x {0 #{0 5},
+                  1 #{4 2}},
+              :y {0 #{0 2},
+                  1 #{4 5}}}
+          ko (reduce (partial key-orders ki) {} history)]
+      (is (= ko
+             {:x {0 #{2 4}
+                  2 #{}
+                  4 #{}
+                  5 #{2 4}}
+              :y {0 #{4 5}
+                  2 #{4 5}
+                  4 #{}
+                  5 #{}}}))))
 
-  (testing "Ignores duplicate sequential reads"
-    (let [history [(op/ok 0 :read {:x 0})
-                   (op/ok 0 :read {:x 1})
-                   (op/ok 0 :read {:x 1})
-                   (op/ok 0 :read {:x 1})]]
-      (is (= (graph history)
-             {:x {0 #{1}
-                  1 #{}}}))))
-
-  (testing "Can render graphs for multiple registers"
-    (let [history [(op/ok 0 :read {:x 0 :y 1})
-                   (op/ok 0 :read {:x 1 :y 1})
-                   (op/ok 0 :read {:x 1 :y 2})
-                   (op/ok 0 :read {:x 2 :y 2})]]
-      (is (= (graph history)
-             {:x {0 #{1}
+  (testing "Can bridge missing values"
+    (let [history [{:index 0 :type :ok, :f :read, :value {:x 0, :y 0}}
+                   {:index 2 :type :ok, :f :read, :value {:x 1, :y 1}}
+                   {:index 4 :type :ok, :f :read, :value {:x 4, :y 1}}
+                   {:index 5 :type :ok, :f :read, :value {:x 0, :y 1}}]
+          ki {:x {0 #{0 5}
                   1 #{2}
-                  2 #{}}
-              :y {1 #{2}
-                  2 #{}}})))))
+                  4 #{4}}
+              :y {0 #{0}
+                  1 #{2 4 5}}}
+          ko (reduce (partial key-orders ki) {} history)]
+      (is (= ko
+             {:x {0 #{2}
+                  2 #{4}
+                  4 #{}
+                  5 #{2}}
+              :y {0 #{4 2 5}
+                  2 #{}
+                  4 #{}
+                  5 #{}}})))))
 
-(deftest errors-test
-  (testing "Flags lööps"
-    (let [graph {:x {1 #{2}
-                     2 #{1}}}
-          components (map-vals tarjan graph)
-          e          (map-vals errors components)]
-      (is (= e
-             {:x {#{1 2} true}}))))
-
-  (testing "Doesn't flag lööpless"
-    (let [graph {:x {1 #{1}
-                     2 #{1}}}
-          components (map-vals tarjan graph)
-          e          (map-vals errors components)]
-      (is (= e {:x nil}))))
-
-  (testing "Flags multiple lööps"
-    (let [graph {:x {1 #{2}
-                     2 #{1}}
-                 :y {3 #{4}
-                     4 #{3}}}
-          components (map-vals tarjan graph)
-          e          (map-vals errors components)]
-      (is (= e {:x {#{1 2} true}
-                :y {#{3 4} true}}))))
-
-  (testing "Flags mixed lööps and lööpless"
-    (let [graph {:x {1 #{2}
-                     2 #{1}
-                     3 #{4}
-                     4 #{}
-                     5 #{}}
-                 :y {0 #{1}
-                     1 #{2}
-                     2 #{}}}
-          components (map-vals tarjan graph)
-          e          (map-vals errors components)]
-      (is (= e {:x {#{1 2} true}
-                :y nil}))))
-
-  (testing "Doesn't flag multiple lööpless"
-    (let [graph {:x {1 #{1}
-                     2 #{1}}
-                 :y {0 #{1}
-                     1 #{}}}
-          components (map-vals tarjan graph)
-          e          (map-vals errors components)]
-      (is (= e {:x nil
-                :y nil})))))
+(deftest precedence-graph-test
+  (testing "can build a precedence graph from a history"
+    (let [history [{:index 0 :type :ok, :f :read, :value {:x 0, :y 0}}
+                   {:index 2 :type :ok, :f :read, :value {:x 1, :y 0}}
+                   {:index 4 :type :ok, :f :read, :value {:x 1, :y 1}}
+                   {:index 5 :type :ok, :f :read, :value {:x 0, :y 1}}]
+          graph (precedence-graph history)]
+      (is (= graph
+             {0 #{2 4 5},
+              2 #{4 5},
+              4 #{},
+              5 #{2 4}})))))
 
 (defn big-history-gen
   [v]
-  (let [f    (rand-nth [:write :read])
+  (let [f    (rand-nth [:inc :read])
         proc (rand-int 100)
-        k    (rand-nth [:x :y])
+        k    (rand-nth [[:x] [:y] [:x :y]])
         type (rand-nth [:ok :ok :ok :ok :ok
                         :fail :info :info])]
     [{:process proc, :type :invoke, :f f, :value {k v}}
@@ -162,38 +144,27 @@
 (deftest checker-test
   (testing "Can validate histories"
     (let [checker (checker)
-          history [(op/invoke 0 :read nil)
-                   (op/ok     0 :read {:x 0 :y 0})
-                   (op/invoke 0 :write {:x 1})
-                   (op/ok     0 :write {:y 1})
-                   (op/invoke 0 :read nil)
-                   (op/ok     0 :read {:x 1 :y 1})]
+          history [{:index 0 :type :invoke :process 0 :f :read :value nil}
+                   {:index 1 :type :ok     :process 0 :f :read :value {:x 0 :y 0}}
+                   {:index 2 :type :invoke :process 0 :f :inc :value [:x]}
+                   {:index 3 :type :ok     :process 0 :f :inc :value [:y]}
+                   {:index 4 :type :invoke :process 0 :f :read :value nil}
+                   {:index 5 :type :ok     :process 0 :f :read :value {:x 1 :y 1}}]
           r (checker/check checker nil history nil)]
       (is (:valid? r))))
 
   (testing "Can invalidate histories"
     (let [checker (checker)
-          history [(op/invoke 0 :read nil)
-                   (op/ok     0 :read {:x 0 :y 0})
-                   (op/invoke 0 :read nil)
-                   (op/ok     0 :read {:x 1 :y 1})
-                   (op/invoke 0 :read nil)
-                   (op/ok     0 :read {:x 0 :y 1})
-                   (op/ok     0 :read {:x 2 :y 4})
-                   (op/ok     0 :read {:x 2 :y 4})]
+          history [{:index 0 :type :invoke :process 0 :f :read :value nil}
+                   {:index 1 :type :ok     :process 0 :f :read :value {:x 0 :y 0}}
+                   {:index 2 :type :invoke :process 0 :f :read :value nil}
+                   {:index 3 :type :ok     :process 0 :f :read :value {:x 1 :y 1}}
+                   {:index 4 :type :invoke :process 0 :f :read :value nil}
+                   {:index 5 :type :ok     :process 0 :f :read :value {:x 0 :y 1}}
+                   {:index 6 :type :ok     :process 0 :f :read :value {:x 2 :y 4}}
+                   {:index 7 :type :ok     :process 0 :f :read :value {:x 2 :y 4}}]
           r (checker/check checker nil history nil)]
       (is (not (:valid? r)))))
-
-  (testing "Auto-validates single-key histories"
-    (let [checker (checker)
-          history [(op/invoke 0 :read nil)
-                   (op/ok     0 :read 0)
-                   (op/invoke 0 :read nil)
-                   (op/ok     0 :read 1)
-                   (op/invoke 0 :read nil)
-                   (op/ok     0 :read 0)]
-          r (checker/check checker nil history nil)]
-      (is (:valid? r))))
 
   (testing "Can handle large histories"
     (let [checker (checker)
@@ -201,21 +172,22 @@
                        (mapcat big-history-gen)
                        (take 10000)
                        vec)
+          history  (map-indexed #(assoc %2 :index %1) history)
           r (checker/check checker nil history nil)]
       (is (:valid? r)))))
 
 (defn read-only-gen
   [v]
   (let [proc (rand-int 100)]
-    [{:process proc, :type :invoke, :f :read, :value v}
-     {:process proc, :type :ok,     :f :read, :value v}]))
+    [{:process proc, :type :ok, :f :read, :value {:x v :y v}}]))
 
 (deftest ^:integration stackoverflow-test
   (testing "just inducing the depth limit problem"
     (let [checker (checker)
           history (->> (range)
                        (mapcat read-only-gen)
-                       (take 100000000)
+                       (take 1000000)
+                       (map-indexed #(assoc %2 :index %1))
                        vec)]
       (time
        (dotimes [n 1]

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -111,7 +111,7 @@
           r (checker/check checker nil history nil)]
       (is (not (:valid? r)))))
 
-  (testing "Can handle large histories"
+  #_(testing "Can handle large histories"
     (let [checker   (checker)
           history   (->> (range)
                          (mapcat big-history-gen)

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -1,0 +1,41 @@
+(ns jepsen.tests.monotonic-cycle-test
+  (:require [jepsen.tests.monotonic-cycle :refer :all]
+            [jepsen.checker :as checker]
+            [knossos.op :as op]
+            [clojure.test :refer :all]))
+
+(def numeric-graph
+  {1 #{2},
+   2 #{3},
+   3 #{1},
+   4 #{2 3 5},
+   5 #{4 6},
+   6 #{3 7},
+   7 #{6},
+   8 #{7 8}})
+
+(def key-graph
+  {:a #{:b},
+   :b #{:c},
+   :c #{:a},
+   :d #{:b :c :e},
+   :e #{:d :f},
+   :f #{:c :g},
+   :g #{:f},
+   :h #{:f :h}})
+
+(deftest tarjan-test
+  (testing "Returns strongly connected components"
+    ;; Graph is taken from the wikipedia page
+    (is (= (tarjan (keys key-graph) key-graph)
+           #{#{:c :b :a} #{:g :f} #{:e :d} #{:h}}))))
+
+(deftest cycle-test
+  (testing "Can flag cyclic reads"
+    (let [c (checker)
+          history [(op/invoke 0 :read nil)
+                   (op/ok     0 :read [0 1])
+                   (op/invoke 0 :read nil)
+                   (op/ok     0 :read [1 0])]
+          r (checker/check checker nil history nil)]
+      (is (not (:valid? r))))))

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -1,6 +1,7 @@
 (ns jepsen.tests.monotonic-cycle-test
   (:require [jepsen.tests.monotonic-cycle :refer :all]
             [jepsen.checker :as checker]
+            [jepsen.util :refer [map-vals]]
             [knossos.op :as op]
             [clojure.test :refer :all]))
 
@@ -11,7 +12,7 @@
                  :c #{:a}    :d #{:b :c :e}
                  :e #{:d :f} :f #{:c :g}
                  :g #{:f}    :h #{:f :h}}]
-      (is (= (tarjan (keys graph) graph)
+      (is (= (tarjan graph)
               #{#{:c :b :a} #{:g :f} #{:e :d} #{:h}}))))
 
   (testing "Can analyze integer graphs"
@@ -19,7 +20,7 @@
                  3 #{1}   4 #{2 3 5}
                  5 #{4 6} 6 #{3 7}
                  7 #{6}   8 #{7 8}}]
-      (is (= (tarjan (keys graph) graph)
+      (is (= (tarjan graph)
              #{#{3 2 1} #{6 7} #{5 4} #{8}}))))
 
   (testing "Can detect when the whole graph is strongly connected"
@@ -27,80 +28,143 @@
                  3 #{4} 4 #{5}
                  5 #{6} 6 #{7}
                  7 #{8} 8 #{1}}]
-      (is (= (tarjan (keys graph) graph)
+      (is (= (tarjan graph)
              #{#{1 2 3 4 5 6 7 8}}))))
 
   (testing "Can verify that no SCCs exist"
     ;; A node with no strong connections is returned as a single-element set
     (let [graph {1 #{} 2 #{} 3 #{} 4 #{}
                  5 #{} 6 #{} 7 #{} 8 #{}}]
-      (is (= (tarjan (keys graph) graph)
+      (is (= (tarjan graph)
              #{#{1} #{2} #{3} #{4}
                #{5} #{6} #{7} #{8}})))
 
     ;; Self connections are equivalent to no connections in this impl.
     (let [graph {1 #{1} 2 #{2} 3 #{3} 4 #{4}}]
-      (is (= (tarjan (keys graph) graph)
+      (is (= (tarjan graph)
              #{#{1} #{2} #{3} #{4}})))))
 
 (deftest graph-test
   (testing "Can render a linear partial order"
-    (let [history [(op/ok 0 :read 0)
-                   (op/ok 0 :read 1)]]
+    (let [history [(op/ok 0 :read {:x 0})
+                   (op/ok 0 :read {:x 1})]]
       (is (= (graph history)
-             {0 #{1} 1 #{}}))))
+             {:x {0 #{1}
+                  1 #{}}}))))
 
   (testing "Can render a circular partial order"
-    (let [history [(op/ok 0 :read 0)
-                   (op/ok 0 :read 1)
-                   (op/ok 0 :read 0)]]
+    (let [history [(op/ok 0 :read {:x 0})
+                   (op/ok 0 :read {:x 1})
+                   (op/ok 0 :read {:x 0})]]
       (is (= (graph history)
-             {0 #{1} 1 #{0}}))))
+             {:x {0 #{1}
+                  1 #{0}}}))))
 
   (testing "Ignores duplicate sequential reads"
-    (let [history [(op/ok 0 :read 0)
-                   (op/ok 0 :read 1)
-                   (op/ok 0 :read 1)
-                   (op/ok 0 :read 1)]]
+    (let [history [(op/ok 0 :read {:x 0})
+                   (op/ok 0 :read {:x 1})
+                   (op/ok 0 :read {:x 1})
+                   (op/ok 0 :read {:x 1})]]
       (is (= (graph history)
-             {0 #{1} 1 #{}})))))
+             {:x {0 #{1}
+                  1 #{}}}))))
+
+  (testing "Can render graphs for multiple registers"
+    (let [history [(op/ok 0 :read {:x 0 :y 1})
+                   (op/ok 0 :read {:x 1 :y 1})
+                   (op/ok 0 :read {:x 1 :y 2})
+                   (op/ok 0 :read {:x 2 :y 2})]]
+      (is (= (graph history)
+             {:x {0 #{1}
+                  1 #{2}
+                  2 #{}}
+              :y {1 #{2}
+                  2 #{}}})))))
 
 (deftest errors-test
   (testing "Flags lööps"
-    (let [graph {1 #{2} 2 #{1}}
-          components (tarjan (keys graph) graph)]
-      (is (= (errors components)
-             {#{1 2} true}))))
+    (let [graph {:x {1 #{2}
+                     2 #{1}}}
+          components (map-vals tarjan graph)
+          e          (map-vals errors components)]
+      (is (= e
+             {:x {#{1 2} true}}))))
 
   (testing "Doesn't flag lööpless"
-    (let [graph {1 #{1} 2 #{1}}
-          components (tarjan (keys graph) graph)]
-      (is (= (errors components)
-             {#{1} false
-              #{2} false})))))
+    (let [graph {:x {1 #{1}
+                     2 #{1}}}
+          components (map-vals tarjan graph)
+          e          (map-vals errors components)]
+      (is (= e {:x nil}))))
+
+  (testing "Flags multiple lööps"
+    (let [graph {:x {1 #{2}
+                     2 #{1}}
+                 :y {3 #{4}
+                     4 #{3}}}
+          components (map-vals tarjan graph)
+          e          (map-vals errors components)]
+      (is (= e {:x {#{1 2} true}
+                :y {#{3 4} true}}))))
+
+  (testing "Flags mixed lööps and lööpless"
+    (let [graph {:x {1 #{2}
+                     2 #{1}
+                     3 #{4}
+                     4 #{}
+                     5 #{}}
+                 :y {0 #{1}
+                     1 #{2}
+                     2 #{}}}
+          components (map-vals tarjan graph)
+          e          (map-vals errors components)]
+      (is (= e {:x {#{1 2} true}
+                :y nil}))))
+
+  (testing "Doesn't flag multiple lööpless"
+    (let [graph {:x {1 #{1}
+                     2 #{1}}
+                 :y {0 #{1}
+                     1 #{}}}
+          components (map-vals tarjan graph)
+          e          (map-vals errors components)]
+      (is (= e {:x nil
+                :y nil})))))
 
 (defn big-history-gen
   [v]
-  (let [f (rand-nth [:write :read])
+  (let [f    (rand-nth [:write :read])
         proc (rand-int 100)
+        k    (rand-nth [:x :y])
         type (rand-nth [:ok :ok :ok :ok :ok
                         :fail :info :info])]
-    [{:process proc, :type :invoke, :f f, :value v}
-     {:process proc, :type type,    :f f, :value v}]))
+    [{:process proc, :type :invoke, :f f, :value {k v}}
+     {:process proc, :type type,    :f f, :value {k v}}]))
 
 (deftest checker-test
   (testing "Can validate histories"
     (let [checker (checker)
           history [(op/invoke 0 :read nil)
-                   (op/ok     0 :read 0)
-                   (op/invoke 0 :write 1)
-                   (op/ok     0 :write 1)
+                   (op/ok     0 :read {:x 0 :y 0})
+                   (op/invoke 0 :write {:x 1})
+                   (op/ok     0 :write {:y 1})
                    (op/invoke 0 :read nil)
-                   (op/ok     0 :read 1)]
+                   (op/ok     0 :read {:x 1 :y 1})]
           r (checker/check checker nil history nil)]
       (is (:valid? r))))
 
   (testing "Can invalidate histories"
+    (let [checker (checker)
+          history [(op/invoke 0 :read nil)
+                   (op/ok     0 :read {:x 0 :y 0})
+                   (op/invoke 0 :read nil)
+                   (op/ok     0 :read {:x 1 :y 1})
+                   (op/invoke 0 :read nil)
+                   (op/ok     0 :read {:x 0 :y 1})]
+          r (checker/check checker nil history nil)]
+      (is (not (:valid? r)))))
+
+  (testing "Auto-validates single-key histories"
     (let [checker (checker)
           history [(op/invoke 0 :read nil)
                    (op/ok     0 :read 0)
@@ -109,13 +173,32 @@
                    (op/invoke 0 :read nil)
                    (op/ok     0 :read 0)]
           r (checker/check checker nil history nil)]
-      (is (not (:valid? r)))))
+      (is (:valid? r))))
 
-  #_(testing "Can handle large histories"
+  (testing "Can handle large histories"
     (let [checker (checker)
           history (->> (range)
                        (mapcat big-history-gen)
                        (take 10000)
                        vec)
-          r (time (checker/check checker nil history nil))]
+          r (checker/check checker nil history nil)]
+      (is (:valid? r)))))
+
+(defn read-only-gen
+  [v]
+  (let [proc (rand-int 100)]
+    [{:process proc, :type :invoke, :f :read, :value v}
+     {:process proc, :type :ok,     :f :read, :value v}]))
+
+;; FIXME Test this on tarjan's directly
+#_(deftest ^:integration stackoverflow-test
+  (testing "just inducing the depth limit problem"
+    (let [checker (checker)
+          history (->> (range)
+                       (mapcat big-history-gen)
+                       (take 5000)
+                       vec)]
+      (time
+       (dotimes [n 100]
+         (checker/check checker nil history nil)))
       (is (:valid? r)))))

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -45,23 +45,23 @@
 
 (deftest graph-test
   (testing "Can render a linear partial order"
-    (let [history [(op/ok     0 :read 0)
-                   (op/ok     0 :read 1)]]
+    (let [history [(op/ok 0 :read 0)
+                   (op/ok 0 :read 1)]]
       (is (= (graph history)
              {0 #{1} 1 #{}}))))
 
   (testing "Can render a circular partial order"
-    (let [history [(op/ok     0 :read 0)
-                   (op/ok     0 :read 1)
-                   (op/ok     0 :read 0)]]
+    (let [history [(op/ok 0 :read 0)
+                   (op/ok 0 :read 1)
+                   (op/ok 0 :read 0)]]
       (is (= (graph history)
              {0 #{1} 1 #{0}}))))
 
   (testing "Ignores duplicate sequential reads"
-    (let [history [(op/ok     0 :read 0)
-                   (op/ok     0 :read 1)
-                   (op/ok     0 :read 1)
-                   (op/ok     0 :read 1)]]
+    (let [history [(op/ok 0 :read 0)
+                   (op/ok 0 :read 1)
+                   (op/ok 0 :read 1)
+                   (op/ok 0 :read 1)]]
       (is (= (graph history)
              {0 #{1} 1 #{}})))))
 
@@ -90,32 +90,32 @@
 
 (deftest checker-test
   (testing "Can validate histories"
-    (let [checker   (checker)
-          history   [(op/invoke 0 :read nil)
-                     (op/ok     0 :read 0)
-                     (op/invoke 0 :write 1)
-                     (op/ok     0 :write 1)
-                     (op/invoke 0 :read nil)
-                     (op/ok     0 :read 1)]
+    (let [checker (checker)
+          history [(op/invoke 0 :read nil)
+                   (op/ok     0 :read 0)
+                   (op/invoke 0 :write 1)
+                   (op/ok     0 :write 1)
+                   (op/invoke 0 :read nil)
+                   (op/ok     0 :read 1)]
           r (checker/check checker nil history nil)]
       (is (:valid? r))))
 
   (testing "Can invalidate histories"
-    (let [checker   (checker)
-          history   [(op/invoke 0 :read nil)
-                     (op/ok     0 :read 0)
-                     (op/invoke 0 :read nil)
-                     (op/ok     0 :read 1)
-                     (op/invoke 0 :read nil)
-                     (op/ok     0 :read 0)]
+    (let [checker (checker)
+          history [(op/invoke 0 :read nil)
+                   (op/ok     0 :read 0)
+                   (op/invoke 0 :read nil)
+                   (op/ok     0 :read 1)
+                   (op/invoke 0 :read nil)
+                   (op/ok     0 :read 0)]
           r (checker/check checker nil history nil)]
       (is (not (:valid? r)))))
 
   #_(testing "Can handle large histories"
-    (let [checker   (checker)
-          history   (->> (range)
-                         (mapcat big-history-gen)
-                         (take 10000)
-                         vec)
+    (let [checker (checker)
+          history (->> (range)
+                       (mapcat big-history-gen)
+                       (take 10000)
+                       vec)
           r (time (checker/check checker nil history nil))]
       (is (:valid? r)))))

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -215,10 +215,10 @@
     (let [checker (checker)
           history (->> (range)
                        (mapcat read-only-gen)
-                       (take 1000000)
+                       (take 100000000)
                        vec)]
       (time
-       (dotimes [n 10]
+       (dotimes [n 1]
          (print "Run" n ":")
          (time (let [r (checker/check checker nil history nil)]
                  (is (:valid? r)))))))))

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -55,7 +55,15 @@
                    (op/ok     0 :read 1)
                    (op/ok     0 :read 0)]]
       (is (= (graph history)
-             {0 #{1} 1 #{0}})))))
+             {0 #{1} 1 #{0}}))))
+
+  (testing "Ignores duplicate sequential reads"
+    (let [history [(op/ok     0 :read 0)
+                   (op/ok     0 :read 1)
+                   (op/ok     0 :read 1)
+                   (op/ok     0 :read 1)]]
+      (is (= (graph history)
+             {0 #{1} 1 #{}})))))
 
 (deftest errors-test
   (testing "Flags lööps"
@@ -109,5 +117,5 @@
                          (mapcat big-history-gen)
                          (take 10000)
                          vec)
-          r (checker/check checker nil history nil)]
+          r (time (checker/check checker nil history nil))]
       (is (:valid? r)))))

--- a/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
+++ b/jepsen/test/jepsen/tests/monotonic_cycle_test.clj
@@ -50,18 +50,50 @@
     (let [graph {0 #{1} 1 #{2}
                  2 #{3} 3 #{}}]
       (is (= (tarjan graph)
-             #{#{3}})))
+             #{#{0} #{1} #{2} #{3}})))
 
-    ;; Our register backtracked >:)
+    ;; Loop
     (let [graph {0 #{1} 1 #{2}
                  2 #{1} 3 #{}}]
       (is (= (tarjan graph)
-             #{#{1 2} #{3}}))))
+             #{#{0} #{1 2} #{3}})))
+
+    ;; Linear but previously bugged case
+    (let [graph {0 #{1} 1 #{2}
+                 2 #{}  3 #{2 1}}]
+      (is (= (tarjan graph)
+             #{#{0} #{1} #{2} #{3}})))
+
+    (let [graph {0 #{1} 1 #{0}
+                 2 #{}  3 #{2 1}}]
+      (is (= (tarjan graph)
+             #{#{0 1} #{2} #{3}})))
+
+    ;; FIXME Busted case
+    (let [graph {1 #{7 3 5} 3 #{7 5}
+                 5 #{}      7 #{3 5}}]
+      (is (= (tarjan graph)
+             #{#{1} #{3 7} #{5}}))))
 
   (testing "can check a one node graph"
     (let [graph {0 #{}}]
       (is (= (tarjan graph)
              #{#{0}})))))
+
+(deftest busted-test
+  #_(let [graph {1 #{7 3 5} 3 #{7 5}
+               5 #{}      7 #{3 5}}]
+    (is (= (tarjan graph)
+           #{#{1} #{3 7} #{5}})))
+
+  ;; WIki
+  (let [graph {1 #{2}   2 #{3}
+               3 #{1}   4 #{2 3 5}
+               5 #{4 6} 6 #{3 7}
+               7 #{6}   8 #{7 8}}]
+    (is (= (tarjan graph)
+           #{#{3 2 1} #{6 7} #{5 4} #{8}})))
+  )
 
 (deftest key-index-test
   (testing "Can produce a key-index from a history"
@@ -142,7 +174,7 @@
      {:process proc, :type type,    :f f, :value {k v}}]))
 
 (deftest checker-test
-  (testing "Can validate histories"
+  #_(testing "Can validate histories"
     (let [checker (checker)
           history [{:index 0 :type :invoke :process 0 :f :read :value nil}
                    {:index 1 :type :ok     :process 0 :f :read :value {:x 0 :y 0}}
@@ -158,15 +190,15 @@
           history [{:index 0 :type :invoke :process 0 :f :read :value nil}
                    {:index 1 :type :ok     :process 0 :f :read :value {:x 0 :y 0}}
                    {:index 2 :type :invoke :process 0 :f :read :value nil}
-                   {:index 3 :type :ok     :process 0 :f :read :value {:x 1 :y 1}}
+                   {:index 3 :type :ok     :process 0 :f :read :value {:x 1 :y 0}}
                    {:index 4 :type :invoke :process 0 :f :read :value nil}
-                   {:index 5 :type :ok     :process 0 :f :read :value {:x 0 :y 1}}
-                   {:index 6 :type :ok     :process 0 :f :read :value {:x 2 :y 4}}
-                   {:index 7 :type :ok     :process 0 :f :read :value {:x 2 :y 4}}]
+                   {:index 5 :type :ok     :process 0 :f :read :value {:x 1 :y 1}}
+                   {:index 6 :type :invoke :process 0 :f :read :value nil}
+                   {:index 7 :type :ok     :process 0 :f :read :value {:x 0 :y 1}}]
           r (checker/check checker nil history nil)]
       (is (not (:valid? r)))))
 
-  (testing "Can handle large histories"
+  #_(testing "Can handle large histories"
     (let [checker (checker)
           history (->> (range)
                        (mapcat big-history-gen)


### PR DESCRIPTION
Got it graphing and validating single-register histories right now. It's fast as heck (usually less than 25ms) for every history i've given it, but it stackoverflows right around the 10k read mark, give or take 2k reads. Gonna figure out what's going on there next week.

Also, I would like guidance on how to get this working with read transactions viewing multiple keys at once.

This is benched against a non-cyclic history. Going to start generating and benching non-monotonic histories once I figure out why it's blowing its stack.
<img width="478" alt="screen shot 2019-03-01 at 5 32 50 pm" src="https://user-images.githubusercontent.com/938395/53675108-14747880-3c48-11e9-9534-0e80ea3f5895.png">