### PR TITLE
Renamed configuration settings.

### DIFF
--- a/faunadb/resources/faunadb.yml
+++ b/faunadb/resources/faunadb.yml
@@ -1,9 +1,9 @@
 ---
+cluster_name: "fauna"
 network_coordinator_http_address: "127.0.0.1"
 network_coordinator_http_port: 8443
 network_admin_http_address: "127.0.0.1"
 network_admin_http_port: 8444
-network_cluster_name: "fauna"
 network_peer_port: 7500
 network_peer_secure_port: 7501
 log_rotate_size_mb: 131072 # 128GB

--- a/faunadb/src/jepsen/faunadb/auto.clj
+++ b/faunadb/src/jepsen/faunadb/auto.clj
@@ -431,7 +431,7 @@
                   {:auth_root_key                  f/root-key
                    :network_coordinator_http_address ip
                    :network_broadcast_address      node
-                   :network_datacenter_name        (topo/replica topo node)
+                   :replica_name                   (topo/replica topo node)
                    :network_host_id                node
                    :network_listen_address         ip}
                   (when (topo/manual-log-config? test)


### PR DESCRIPTION
Eliminates the following warnings emitted when FaunaDB starts:

```
Renamed configuration setting `network_datacenter_name` is now `replica_name`.
Renamed configuration setting `network_cluster_name` is now `cluster_name`.
```