### PR TITLE
Do not insert data before an index is created with active: true.

### DIFF
--- a/faunadb/src/jepsen/faunadb/bank.clj
+++ b/faunadb/src/jepsen/faunadb/bank.clj
@@ -145,14 +145,15 @@
 
   (setup! [this test]
     (f/with-retry
-      (client/setup! bank-client test)
+      (create-class! test conn)
       (f/upsert-index! conn {:name idx-name
                              :source accounts
                              :active true
                              :serialized (boolean (:serialized-indices test))
                              :values [{:field ["ref"]}
                                       {:field ["data" "balance"]}]})
-      (f/wait-for-index conn idx)))
+      (f/wait-for-index conn idx)
+      (create-accounts! test conn)))
 
   (invoke! [this test op]
     (if (= :read (:f op))


### PR DESCRIPTION
In dbe49cc, I had not noticed that the bank-index workload inserts data prior to building an index, which violates the rules for creating indexes with `active: true`. This change resolves that, and will also work for builds wherein `active: true` is not permitted.