### PR TITLE
configurable flakiness

### DIFF
--- a/doc/plan.md
+++ b/doc/plan.md
@@ -12,9 +12,6 @@
 - Rework latency plot color scheme to use colors that hint at a continuum
 - Adaptive temporal resolution for rate and latency plots, based on point
   density
-- Nemesis regions are just lines now. Let's bring back shaded regions for :f
-  :start-foo to :stop-foo? Maybe colorize for each type of nemesis f, when
-  they're mixed together?
 - Where plots are dense, make points somewhat transparent to better show
   density?
 
@@ -28,9 +25,6 @@
 
 ## Performance
 
-- Knossos: we should allow users to pass a :time-limit option, and after that
-  many seconds, abort the search. Relying on OOM detection and abort still
-  means plenty of tests spin for hoooours.
 - Knossos: let's make the memoization threshold configurable via options passed
   to the checker.
 

--- a/doc/plan.md
+++ b/doc/plan.md
@@ -49,3 +49,6 @@
 - Port pure-insert from Cockroach into core
 - Port comments from Cockroach into core (better name?)
 - Port other Hermitage tests to Jepsen?
+
+## Tests
+- Clean up causal test. Drop model and port to workload

--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -21,7 +21,11 @@
          :mean         (in ms)
          :variance     (in ms)
          :distribution (e.g. :normal)")
-  (flaky! [net test]         "Introduces randomized packet loss")
+  (flaky! [net test]
+          [net test ops]
+          "Introduces randomized packet loss with options:
+
+          :lossiness   (as a percentage)")
   (fast! [net test]          "Removes packet loss and delays."))
 
 ; Top-level API functions
@@ -83,9 +87,13 @@
                   :distribution distribution))))
 
     (flaky! [net test]
+      (flaky! net test {:lossiness 30}))
+
+    (flaky! [net test {:keys [lossiness]
+                       :or   {lossiness 30}}]
       (with-test-nodes test
-        (su (exec tc :qdisc :add :dev :eth0 :root :netem :loss "20%"
-                  "75%"))))
+        (su (exec tc :qdisc :add :dev :eth0 :root :netem :loss
+                  (str lossiness "%")))))
 
     (fast! [net test]
       (with-test-nodes test
@@ -120,7 +128,7 @@
 
     (slow! [net test]
       (with-test-nodes test
-        (su (exec :tc :qdisc :add :dev :eth0 :root :netem :delay :50ms
+        (su (exec tc :qdisc :add :dev :eth0 :root :netem :delay :50ms
                   :10ms :distribution :normal))))
 
     (slow! [net test {:keys [mean variance distribution]
@@ -134,10 +142,14 @@
                   :distribution distribution))))
 
     (flaky! [net test]
+      (flaky! net test {:lossiness 30})
+
+    (flaky! [net test {:keys [lossiness]
+                       :or   {lossiness 30}}]
       (with-test-nodes test
-        (su (exec :tc :qdisc :add :dev :eth0 :root :netem :loss "20%"
-                  "75%"))))
+        (su (exec tc :qdisc :add :dev :eth0 :root :netem :loss
+                  (str lossiness "%")))))
 
     (fast! [net test]
       (with-test-nodes test
-        (su (exec :tc :qdisc :del :dev :eth0 :root))))))
+        (su (exec tc :qdisc :del :dev :eth0 :root))))))


### PR DESCRIPTION
Previously, parameters for the `tc` utility for making the network flaky were not configurable, but now they are!