### PR TITLE
docker: Inline tutum/debian and upgrade to stretch

### DIFF
--- a/docker/control/bashrc
+++ b/docker/control/bashrc
@@ -1,3 +1,6 @@
+eval $(ssh-agent) &> /dev/null
+ssh-add /root/.ssh/id_rsa &> /dev/null
+
 cat <<EOF
 Welcome to Jepsen on Docker
 ===========================

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -12,8 +12,6 @@ RUN chmod +x /*.sh
 
 ENV AUTHORIZED_KEYS **None**
 
-RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
-
 RUN apt-get update
 RUN apt install -y apt-transport-https
 RUN apt install -y software-properties-common

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,25 @@
-# FIXME: tutum/debian will be deprecated soon: https://github.com/tutumcloud/tutum-debian/blob/master/README.md
-FROM tutum/debian:jessie
+FROM debian:stretch
 
-RUN rm /etc/apt/apt.conf.d/docker-clean && apt-get update && apt-get install -y bzip2 curl faketime iproute iptables iputils-ping libzip2 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo sysvinit sysvinit-core sysvinit-utils tar unzip vim wget && apt-get remove -y --purge --auto-remove systemd
+# Install packages
+RUN apt-get update && \
+apt-get -y install openssh-server pwgen && \
+mkdir -p /var/run/sshd && \
+sed -i "s/UsePrivilegeSeparation.*/UsePrivilegeSeparation no/g" /etc/ssh/sshd_config && \
+sed -i "s/PermitRootLogin without-password/PermitRootLogin yes/g" /etc/ssh/sshd_config
+
+ADD run.sh /run.sh
+RUN chmod +x /*.sh
+
+ENV AUTHORIZED_KEYS **None**
+
+RUN sed -i '/jessie-updates/d' /etc/apt/sources.list
+
+RUN apt-get update
+RUN apt install -y apt-transport-https
+RUN apt install -y software-properties-common
+
+# Install Jepsen deps
+RUN apt-get install -y build-essential bzip2 curl faketime iproute iptables iputils-ping libzip4 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo tar unzip vim wget && apt-get remove -y --purge --auto-remove systemd
+
+EXPOSE 22
+CMD ["/run.sh"]

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,3 +1,4 @@
+# Based on the deprecated `https://github.com/tutumcloud/tutum-debian`
 FROM debian:stretch
 
 # Install packages
@@ -11,6 +12,9 @@ ADD run.sh /run.sh
 RUN chmod +x /*.sh
 
 ENV AUTHORIZED_KEYS **None**
+
+ADD run.sh /run.sh
+RUN chmod +x /*.sh
 
 RUN apt-get update
 RUN apt install -y apt-transport-https

--- a/docker/node/run.sh
+++ b/docker/node/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+if [ "${AUTHORIZED_KEYS}" != "**None**" ]; then
+    echo "=> Found authorized keys"
+    mkdir -p /root/.ssh
+    chmod 700 /root/.ssh
+    touch /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+    IFS=$'\n'
+    arr=$(echo ${AUTHORIZED_KEYS} | tr "," "\n")
+    for x in $arr
+    do
+        x=$(echo $x |sed -e 's/^ *//' -e 's/ *$//')
+        cat /root/.ssh/authorized_keys | grep "$x" >/dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            echo "=> Adding public key to /root/.ssh/authorized_keys: $x"
+            echo "$x" >> /root/.ssh/authorized_keys
+        fi
+    done
+fi
+
+exec /usr/sbin/sshd -D


### PR DESCRIPTION
This PR inlines the deprecated `tutum/jessie` Dockerfile and upgrades it to `stretch`. Fixes #348.