### PR TITLE
dgraph: Bump to jepsen 0.1.13.

### DIFF
--- a/dgraph/project.clj
+++ b/dgraph/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [jepsen "0.1.12"]
+                 [jepsen "0.1.13"]
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]
                  ; Note that we specify manual versions of dgraph deps since


### PR DESCRIPTION
Updates to setup with Debian Stretch nodes.

Closes #348 (again).