### PR TITLE
Fix docker files

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 services:
   control:
     volumes:

--- a/docker/docker-compose.ubuntu.yml
+++ b/docker/docker-compose.ubuntu.yml
@@ -1,6 +1,12 @@
-version: '2'
+version: '3.7'
+x-ubuntu:
+  &ubuntu
+  build:
+    dockerfile: Dockerfile-ubuntu
+
 services:
-  node:
-    build:
-      context: ./node
-      dockerfile: Dockerfile-ubuntu
+  n1: *ubuntu
+  n2: *ubuntu
+  n3: *ubuntu
+  n4: *ubuntu
+  n5: *ubuntu

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,10 @@
-version: '2'
+version: '3.7'
+x-node:
+  &default-node
+  build: ./node
+  env_file: ./secret/node.env
+  privileged: true
+
 services:
   control:
     container_name: jepsen-control
@@ -14,28 +20,23 @@ services:
       - n3
       - n4
       - n5
-  node:
-    container_name: jepsen-node
-    build: ./node
-    env_file: ./secret/node.env
-    privileged: true
   n1:
-    extends: node
+    << : *default-node
     container_name: jepsen-n1
     hostname: n1
   n2:
-    extends: node
+    << : *default-node
     container_name: jepsen-n2
     hostname: n2
   n3:
-    extends: node
+    << : *default-node
     container_name: jepsen-n3
     hostname: n3
   n4:
-    extends: node
+    << : *default-node
     container_name: jepsen-n4
     hostname: n4
   n5:
-    extends: node
+    << : *default-node
     container_name: jepsen-n5
     hostname: n5

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -48,10 +48,6 @@ do
             shift # past argument
             shift # past value
             ;;
-        --ubuntu)
-            UBUNTU="-f docker-compose.ubuntu.yml"
-            shift # past argument
-            ;;
         -d|--daemon)
             INFO "Running docker-compose as daemon"
             RUN_AS_DAEMON=1
@@ -72,7 +68,6 @@ if [ "$HELP" ]; then
     echo "  --init-only                                           Initializes ssh-keys, but does not call docker-compose"
     echo "  --daemon                                              Runs docker-compose in the background"
     echo "  --dev                                                 Mounts dir at host's JEPSEN_ROOT to /jepsen on jepsen-control container, syncing files for development"
-    echo "  --ubuntu                                              Use Ubuntu instead of Debian as the nodes' OS."
     echo "  --compose PATH                                        Path to an additional docker-compose yml config."
     echo "To provide multiple additional docker-compose args, set the COMPOSE var directly, with the -f flag. Ex: COMPOSE=\"-f FILE_PATH_HERE -f ANOTHER_PATH\" ./up.sh --dev"
     exit 0
@@ -120,14 +115,14 @@ exists docker || { ERROR "Please install docker (https://docs.docker.com/engine/
 exists docker-compose || { ERROR "Please install docker-compose (https://docs.docker.com/compose/install/)"; exit 1; }
 
 INFO "Running \`docker-compose build\`"
-docker-compose -f docker-compose.yml $COMPOSE $UBUNTU $DEV build
+docker-compose -f docker-compose.yml $COMPOSE $DEV build
 
 INFO "Running \`docker-compose up\`"
 if [ "$RUN_AS_DAEMON" ]; then
-    docker-compose -f docker-compose.yml $COMPOSE $UBUNTU $DEV up -d
+    docker-compose -f docker-compose.yml $COMPOSE $DEV up -d
     INFO "All containers started, run \`docker ps\` to view"
     exit 0
 else
     INFO "Please run \`docker exec -it jepsen-control bash\` in another terminal to proceed"
-    docker-compose -f docker-compose.yml $COMPOSE $UBUNTU $DEV up
+    docker-compose -f docker-compose.yml $COMPOSE $DEV up
 fi


### PR DESCRIPTION
This PR fixes the problem I mentioned in https://github.com/jepsen-io/jepsen/issues/360. I decided to use [extension-fields](https://docs.docker.com/compose/compose-file/#extension-fields) in the docker-compose files. It is not pretty, but it solves the problem in the sense that it doesn't matter in which order the docker-compose files are merged.

Also I have removed the `--ubuntu` option from `up.sh` as I think it will simplify things in the long run. Of course we still have the option of running ubuntu nodes using the `--compose docker-compose.ubuntu.yml` option.

One other change which I think would be nice is to parse the command line options with `getops`. As it is now, `up.sh --foo` will run fine but it probably should complain and print out the help. But this is for another PR.

Thank you!