### PR TITLE
jepsen.ignite os dependecy fix 

### DIFF
--- a/ignite/run_test.sh
+++ b/ignite/run_test.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 lein run test \
   --test bank \
   --time-limit 10 \
@@ -12,4 +13,6 @@ lein run test \
   --transaction-concurrency OPTIMISTIC \
   --transaction-isolation SERIALIZABLE \
   --backups 3 \
+  --os noop \
+  --nemesis noop \
   --version 2.7.0

--- a/ignite/src/jepsen/ignite.clj
+++ b/ignite/src/jepsen/ignite.clj
@@ -1,6 +1,7 @@
 (ns jepsen.ignite
   (:require [clojure.tools.logging   :refer :all]
             [clojure.string          :as str]
+            [clojure.java.shell      :as shell]
             [clojure.java.io         :as io]
             [jepsen [core            :as jepsen]
                     [checker         :as checker]
@@ -14,16 +15,48 @@
                     [util            :refer [timeout meh]]]
             [jepsen.control.util     :as cu]
             [jepsen.os.debian        :as debian]
+            [jepsen.os.centos        :as centos]
             [jepsen.checker.timeline :as timeline]
             [knossos.model           :as model])
   (:import (java.io File)
            (java.util UUID)
            (org.apache.ignite Ignition IgniteCache)
-           (clojure.lang ExceptionInfo)))
+           (clojure.lang ExceptionInfo)
+           jepsen.os.debian.Debian
+           jepsen.os.centos.CentOS
+           java.lang.Object))
 
 (def user "ignite")
 (def server-dir "/opt/ignite/")
 (def logfile (str server-dir "node.log"))
+
+; OS-level polymorphic functions for Ignite
+(defprotocol OS
+             (install-jdk8! [os] "Install Oracle JDK 8")
+             (ensure-user! [os user]))
+
+(extend-protocol OS
+
+  Debian
+  (install-jdk8! [os]
+    (debian/install-jdk8!))
+  (ensure-user! [os user]
+    (cu/ensure-user! user))
+
+  CentOS
+  (install-jdk8! [os]
+    ; TODO: figure out the yum invocation we need here
+    )
+  (ensure-user! [os user]
+    (c/su (c/exec :adduser user)))
+
+  Object
+  (install-jdk8! [os]
+    ;JDK should be installed manually
+    )
+  (ensure-user! [os user]
+    ;User should be created manually
+    ))
 
 (defn start!
   "Starts server for the given node."
@@ -44,9 +77,9 @@
 (defn nuke!
   "Shuts down server and destroys all data."
   [node test]
-  (c/su
+   (c/su
     (meh (c/exec :pkill :-9 :-f "org.apache.ignite.startup.cmdline.CommandLineStartup"))
-    (c/exec :rm :-rf server-dir))
+    (c/exec :rm :-rf server-dir)
   (info node "Apache Ignite nuked"))
 
 (defn configure [addresses client-mode]
@@ -72,17 +105,21 @@
   [version]
   (reify db/DB
     (setup! [_ test node]
+      ;if we have no JDK on nodes, when install it. Works only with Debian/Ubuntu
+      (when-not (re-find #"JAVA_HOME" (get (shell/sh "printenv") :out)) (c/su (debian/install-jdk8!)))
       (info node "Installing Apache Ignite" version)
-      (c/su
-        (debian/install-jdk8!)
-        (cu/ensure-user! user)
+       (c/su
+         (install-jdk8! (:os test))
+         (ensure-user! (:os test) user)
         (let [url (str "https://archive.apache.org/dist/ignite/" version "/apache-ignite-" version "-bin.zip")]
           (cu/install-archive! url server-dir))
-        (c/exec :chown :-R (str user ":" user) server-dir))
-      (c/sudo user
+          (c/exec :chown :-R (str user ":" user) server-dir)
+         )
+       (c/sudo user
         (configure-server (:nodes test) node)
         (start! node test)
-        (await-cluster-started node test)))
+        (await-cluster-started node test))
+         )
 
     (teardown! [_ test node]
       (nuke! node test))
@@ -136,6 +173,9 @@
       :transaction-isolation
       :test-fns)
     {:name    "basic-test"
-     :os      debian/os
+     :os      (case (:os options)
+                    :centos centos/os
+                    :debian debian/os
+                    :noop jepsen.os/noop)
      :db      (db (:version options))
-     :nemesis (nemesis/partition-random-halves)}))
+     :nemesis (:nemesis options)}))

--- a/ignite/src/jepsen/ignite/runner.clj
+++ b/ignite/src/jepsen/ignite/runner.clj
@@ -4,6 +4,7 @@
   (:require [clojure.pprint :refer [pprint]]
             [clojure.tools.logging :refer :all]
             [jepsen.cli :as jc]
+            [jepsen.nemesis :as nemesis]
             [jepsen.core :as jepsen]
             [jepsen.ignite  [register :as register]
                             [bank     :as bank]])
@@ -42,6 +43,10 @@
   {"SERIALIZABLE"    TransactionIsolation/SERIALIZABLE
    "READ_COMMITTED"  TransactionIsolation/READ_COMMITTED
    "REPEATABLE_READ" TransactionIsolation/REPEATABLE_READ})
+
+(def nemesis-types
+  {"noop"                   nemesis/noop
+  "partition-random-halves" nemesis/partition-random-halves})
 
 (def opt-spec
   "Command line options for tools.cli"
@@ -89,7 +94,16 @@
     :validate [pos? "Must be positive"]]
    ["-v" "--version VERSION"
     "What version of Apache Ignite to install"
-    :default "2.7.0"]])
+    :default "2.7.0"]
+   ["-o" "--os NAME" "Operating system: either centos or debian."
+    :default  :noop
+    :parse-fn keyword
+    :validate [#{:centos :debian :noop} "One of `centos` or `debian` or 'noop'"]]
+   ["-nemesis" "--nemesis Nemesis"
+    "What Nemesis to use"
+    :default nemesis/noop
+    :parse-fn nemesis-types
+    :validate [identity (jc/one-of nemesis-types)]]])
 
 (defn log-test
   [t]

--- a/tidb/src/tidb/bank.clj
+++ b/tidb/src/tidb/bank.clj
@@ -16,7 +16,7 @@
 (defrecord BankClient [conn]
   client/Client
   (open! [this test node]
-    (assoc this :conn (c/open node)))
+    (assoc this :conn (c/open node test)))
 
   (setup! [this test]
     (j/execute! conn ["create table if not exists accounts
@@ -93,7 +93,7 @@
 (defrecord MultiBankClient [conn tbl-created?]
   client/Client
   (open! [this test node]
-    (assoc this :conn (c/open node)))
+    (assoc this :conn (c/open node test)))
 
   (setup! [this test]
     (locking tbl-created?

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -38,7 +38,7 @@
 
 (def opt-spec
   "Command line options for tools.cli"
-  [[nil "--auto-retry" "Enables automatic retries"
+  [[nil "--auto-retry" "Enables automatic retries (the default for TiDB)"
     :default false]
 
    (jc/repeated-opt nil "--nemesis NAME" "Which nemeses to use"

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -38,7 +38,10 @@
 
 (def opt-spec
   "Command line options for tools.cli"
-  [(jc/repeated-opt nil "--nemesis NAME" "Which nemeses to use"
+  [[nil "--auto-retry" "Enables automatic retries"
+    :default false]
+
+   (jc/repeated-opt nil "--nemesis NAME" "Which nemeses to use"
                     [`(nemesis/none)]
                     nemeses)
 

--- a/tidb/src/tidb/register.clj
+++ b/tidb/src/tidb/register.clj
@@ -21,7 +21,7 @@
   client/Client
 
   (open! [this test node]
-    (assoc this :conn (c/open node)))
+    (assoc this :conn (c/open node test)))
 
   (setup! [this test]
     (j/execute! conn ["drop table if exists test"])

--- a/tidb/src/tidb/sequential.clj
+++ b/tidb/src/tidb/sequential.clj
@@ -1,11 +1,26 @@
 (ns tidb.sequential
+  "A sequential consistency test.
+
+  Verify that client order is consistent with DB order by performing queries
+  (in four distinct transactions) like
+
+  A: insert x
+  A: insert y
+  B: read y
+  B: read x
+
+  A's process order enforces that x must be visible before y, so we should
+  always read both or neither.
+
+  Splits keys up onto different tables to make sure they fall in different
+  shard ranges"
   (:refer-clojure :exclude [test])
   (:require [jepsen [client :as client]
-                    [checker :as checker]
-                    [core :as jepsen]
-                    [generator :as gen]
-                    [independent :as independent]
-                    [util :as util :refer [meh]]]
+             [checker :as checker]
+             [core :as jepsen]
+             [generator :as gen]
+             [independent :as independent]
+             [util :as util :refer [meh]]]
             [clojure.java.jdbc :as j]
             [clojure.set :as set]
             [clojure.tools.logging :refer :all]
@@ -136,14 +151,15 @@
 
 (defn test
   [opts]
-  (let [gen       (gen 10)
+  (let [c         (:concurrency opts)
+        gen       (gen (/ c 2))
         keyrange (atom {})]
     (basic/basic-test
      (merge
       {:name "sequential"
        :key-count 5
        :keyrange  keyrange
-       :client {:client (SequentialClient. 10 (atom false) nil)
+       :client {:client (SequentialClient. c (atom false) nil)
                 :during (gen/stagger 1/100 gen)
                 :final nil}
        :checker (checker/compose

--- a/tidb/src/tidb/sequential.clj
+++ b/tidb/src/tidb/sequential.clj
@@ -35,7 +35,7 @@
 (defrecord SequentialClient [table-count tbl-created? conn]
   client/Client
   (open! [this test node]
-    (assoc this :conn (c/open node)))
+    (assoc this :conn (c/open node test)))
 
   (setup! [this test]
     (Thread/sleep 2000)

--- a/tidb/src/tidb/sets.clj
+++ b/tidb/src/tidb/sets.clj
@@ -16,38 +16,44 @@
   (setup! [this test]
     (j/execute! conn ["create table if not exists sets
                       (id     int not null primary key auto_increment,
-                      value bigint not null)"]))
+                       value  bigint not null)"]))
 
   (invoke! [this test op]
-    (with-txn op [c conn]
-      (case (:f op)
-        :add  (do (j/insert! c :sets (select-keys op [:value]))
-                  (assoc op :type :ok))
-        :read (->> (j/query c ["select * from sets"])
-                   (mapv :value)
-                   (into (sorted-set))
-                   (assoc op :type :ok, :value)))))
+    (c/with-error-handling op
+      (c/with-txn-aborts op
+        (case (:f op)
+          :add  (do (j/insert! conn :sets (select-keys op [:value]))
+                    (assoc op :type :ok))
+
+          :read (->> (j/query conn ["select * from sets"])
+                     (mapv :value)
+                     (assoc op :type :ok, :value))))))
 
   (teardown! [_ test])
 
   (close! [_ test]
     (c/close! conn)))
 
+(defn adds
+  []
+  (->> (range)
+       (map (fn [x] {:type :invoke, :f :add, :value x}))
+       (gen/seq)))
+
+(defn reads
+  []
+  {:type :invoke, :f :read, :value nil})
+
 (defn test
   [opts]
-  (basic/basic-test
-    (merge
-    {:name "set"
-     :client {:client (SetClient. nil)
-              :during (->> (range)
-                          (map (partial array-map
-                                        :type :invoke
-                                        :f :add
-                                        :value))
-                          gen/seq
-                          (gen/stagger 1))
-              :final (gen/once {:type :invoke, :f :read, :value nil})}
-     :checker (checker/compose
-                {:perf (checker/perf)
-                 :set  (checker/set)})}
-     opts)))
+  (let [c (:concurrency opts)]
+    (basic/basic-test
+      (merge
+        {:name "set"
+         :client {:client (SetClient. nil)
+                  :during (->> (gen/reserve (/ c 2) (adds) (reads))
+                               (gen/stagger 1/10))}
+         :checker (checker/compose
+                    {:perf (checker/perf)
+                     :set  (checker/set-full)})}
+        opts))))

--- a/tidb/src/tidb/sets.clj
+++ b/tidb/src/tidb/sets.clj
@@ -11,7 +11,7 @@
 (defrecord SetClient [conn]
   client/Client
   (open! [this test node]
-    (assoc this :conn (c/open node)))
+    (assoc this :conn (c/open node test)))
 
   (setup! [this test]
     (j/execute! conn ["create table if not exists sets

--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -31,8 +31,6 @@
   [conn test]
   (j/execute! conn ["set @@global.tidb_disable_txn_auto_retry = ?"
                     (if (:auto-retry test) 0 1)])
-  (info :auto-retry (j/query conn
-                             ["select @@global.tidb_disable_txn_auto_retry"]))
   conn)
 
 (defn open

--- a/tidb/src/tidb/sql.clj
+++ b/tidb/src/tidb/sql.clj
@@ -29,7 +29,7 @@
 
   Returns conn."
   [conn test]
-  (j/execute! conn ["set @@global.tidb_disable_txn_auto_retry = ?"
+  (j/execute! conn ["set @@tidb_disable_txn_auto_retry = ?"
                     (if (:auto-retry test) 0 1)])
   conn)
 


### PR DESCRIPTION
Added the ability to select the OS.
Now you can run tests on an already configured OS and if there are no root rights

Added the ability to select Nemesis

Removed add user code from ignite/src/jepsen/ignite.clj.
ensure-user! does not work on centos because of adduser different syntax. Also does not work if you do not have root rights.