### PR TITLE
Update Dgraph docker-compose version.

### DIFF
--- a/dgraph/docker/docker-compose.yml
+++ b/dgraph/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 services:
   control:
     volumes:


### PR DESCRIPTION
Fixes version mismatch error when running `./up.sh --compose ../dgraph/docker/docker-compose.yml` due to recent changes to base docker-compose.yml file:

    ERROR: Version mismatch: file ./docker-compose.yml specifies version 3.7 but extension file ./../dgraph/docker/docker-compose.yml uses version 2.0