### PR TITLE
Tutorial: update for 0.1.13

### DIFF
--- a/doc/tutorial/01-scaffolding.md
+++ b/doc/tutorial/01-scaffolding.md
@@ -38,8 +38,8 @@ Verschlimmbesserung: a library for talking to etcd.
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main jepsen.etcdemo
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [jepsen "0.1.8"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [jepsen "0.1.13"]
                  [verschlimmbesserung "0.1.3"]])
 ```
 

--- a/doc/tutorial/03-client.md
+++ b/doc/tutorial/03-client.md
@@ -256,7 +256,7 @@ automatically convert it to an `:info` crash.
                (case (:f op)
                  :read (assoc op :type :ok, :value (v/get conn "foo"))
                  :write (do (v/reset! conn "foo" (:value op))
-                            (assoc op :type, :ok))))
+                            (assoc op :type :ok))))
 ```
 
 We'll confirm writes work by watching the test:

--- a/doc/tutorial/04-checker.md
+++ b/doc/tutorial/04-checker.md
@@ -88,7 +88,12 @@ register. Reads are similar, except that we always allow reads of `nil` to pass
 through. This allows us to satisfy histories which include reads that never
 returned.
 
-We'll add this to our test by providing a `:model` field.
+To analyze the history, we'll specify a `:checker` for the test, and provide a
+`:model` to specify how the system *should* behave.
+`checker/linearizable` uses the Knossos linearizability checker to verify that
+every operation appears take place atomically between its invocation and
+completion. The linearizable checker requires a model and to specify a specific
+algorithm which we pass to it in an options map.
 
 ```clj
 (defn etcd-test
@@ -101,8 +106,8 @@ We'll add this to our test by providing a `:model` field.
           :os         debian/os
           :db         (db "v3.1.5")
           :client     (Client. nil)
-          :model      (model/cas-register)
-          :checker    (checker/linearizable)
+          :checker    (checker/linearizable {:model     (model/cas-register)
+                                             :algorithm :linear})
           :generator  (->> (gen/mix [r w cas])
                            (gen/stagger 1)
                            (gen/nemesis nil)
@@ -110,31 +115,26 @@ We'll add this to our test by providing a `:model` field.
 
 ```
 
-To analyze the history, we'll specify a `:checker` for the test.
-`checker/linearizable` uses the Knossos linearizability checker to verify that
-every operation appears take place atomically between its invocation and
-completion. It'll use the test's `:model` to specify how the system *should*
-behave.
-
 Running the test, we can confirm the checker's results:
 
 ```bash
 $ lein run test
 ...
-INFO [2017-03-31 17:38:16,855] jepsen worker 0 - jepsen.util 0  :invoke :write  1
-INFO [2017-03-31 17:38:16,861] jepsen worker 0 - jepsen.util 0  :ok :write  1
+INFO [2019-04-17 17:38:16,855] jepsen worker 0 - jepsen.util 0  :invoke :write  1
+INFO [2019-04-17 17:38:16,861] jepsen worker 0 - jepsen.util 0  :ok :write  1
 ...
-INFO [2017-03-31 17:38:19,307] main - jepsen.core {:valid? true,
+INFO [2019-04-18 03:53:32,714] jepsen test runner - jepsen.core {:valid? true,
  :configs
  ({:model {:value 1},
    :last-op
-   {:type :ok,
+   {:process 3,
+    :type :ok,
     :f :write,
     :value 1,
-    :process 0,
-    :time 15534211500,
-    :index 37},
+    :index 151,
+    :time 14796541900},
    :pending []}),
+ :analyzer :linear,
  :final-paths ()}
 
 
@@ -154,8 +154,9 @@ performance graphs.
 
 ```clj
          :checker (checker/compose
-                    {:perf   (checker/perf)
-                     :linear (checker/linearizable)})
+                     {:perf   (checker/perf)
+                      :linear (checker/linearizable {:model     (model/cas-register)
+                                                     :algorithm :linear})})
 ```
 
 ```bash
@@ -176,10 +177,11 @@ We can also generate HTML visualizations of the history. Let's add the `jepsen.c
 And add that checker to the test:
 
 ```clj
-          :checker    (checker/compose
-                        {:perf      (checker/perf)
-                         :linear    (checker/linearizable)
-                         :timeline  (timeline/html)})
+          :checker (checker/compose
+                     {:perf   (checker/perf)
+                      :linear (checker/linearizable {:model     (model/cas-register)
+                                                     :algorithm :linear})
+                      :timeline (timeline/html)})
 ```
 
 Now we can plot how different processes performed operations over time--which

--- a/doc/tutorial/06-refining.md
+++ b/doc/tutorial/06-refining.md
@@ -193,12 +193,13 @@ Finally, our checker thinks in terms of a single value--but we can turn that
 into a checker that reasons about *independent* values, identified by keys.
 
 ```clj
-          :checker  (checker/compose 
-                      {:perf  (checker/perf)
-                       :indep (independent/checker 
-                                (checker/compose 
-                                {:timeline (timeline/html)
-                                 :linear (checker/linearizable)}))})
+          :checker   (checker/compose
+                       {:perf  (checker/perf)
+                        :indep (independent/checker
+                                 (checker/compose
+                                   {:linear   (checker/linearizable {:model (model/cas-register)
+                                                                     :algorithm :linear})
+                                    :timeline (timeline/html)}))})
 ```
 
 Write one checker, get a family of n checkers for free! Maaaaagic!

--- a/doc/tutorial/07-parameters.md
+++ b/doc/tutorial/07-parameters.md
@@ -181,9 +181,12 @@ as a rate per second, and change our hardcoded limit on each key's generator to 
             :nemesis    (nemesis/partition-random-halves)
             :model      (model/cas-register)
             :checker    (checker/compose
-                          {:perf      (checker/perf)
-                           :linear    (independent/checker (checker/linearizable))
-                           :timeline  (independent/checker (timeline/html))})
+                          {:perf  (checker/perf)
+                           :indep (independent/checker
+                                    (checker/compose
+                                      {:linear   (checker/linearizable {:model     (model/cas-register)
+                                                                        :algorithm :linear})
+                                       :timeline (timeline/html)}))})
             :generator  (->> (independent/concurrent-generator
                                10
                                (range)

--- a/doc/tutorial/08-set.md
+++ b/doc/tutorial/08-set.md
@@ -195,7 +195,7 @@ dispatch based on `:f`, and use a similar error handler.
     (try+
       (case (:f op)
         :read (assoc op
-                     :type :ok,
+                     :type :ok
                      :value (read-string
                               (v/get conn k {:quorum? (:quorum test)})))
 ```
@@ -411,7 +411,8 @@ Let's rewrite the linearizable register test as a workload, so it has the same s
   {:client    (Client. nil)
    :checker   (independent/checker
                 (checker/compose
-                  {:linear   (checker/linearizable)
+                  {:linear   (checker/linearizable {:model     (model/cas-register)
+                                                    :algorithm :linear})
                    :timeline (timeline/html)}))
 ```
 
@@ -468,7 +469,6 @@ name.
             :os         debian/os
             :db         (db "v3.1.5")
             :nemesis    (nemesis/partition-random-halves)
-            :model      (model/cas-register)
             :client     (:client workload)
             :checker    (checker/compose
                           {:perf     (checker/perf)


### PR DESCRIPTION
Hi, this PR is just some small updates to the tutorial so that it is compatible with Jepsen 0.1.13. Basically moving `:model` from the test opts to the linearizable checker. Thanks!