### PR TITLE
jepsen.os.debian: add a function to install openjdk-8-jre

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -136,6 +136,11 @@
     (install [:oracle-java8-installer])
     (install [:oracle-java8-set-default])))
 
+(defn install-openjdk-8-jre!
+  "Installs OpenJDK Java runtime, using Hotspot JIT"
+  []
+  (c/su (install [:openjdk-8-jre])))
+
 (deftype Debian []
   os/OS
   (setup! [_ test node]


### PR DESCRIPTION
Hello! I don't know if you will consider adding this, but this functions allows installing the openjdk-8-jre on debian. The current `install-jdk8` does not seem to work at the moment. I get an `ExecutionException` as attached below. (Sorry a bit hard to read). 

```
java.util.concurrent.ExecutionException: clojure.lang.ExceptionInfo: throw+: {:type :jepsen.control/nonzero-exit, :cmd "sudo -S -u root bash -c \"cd /; env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes oracle-java8-installer\"", :exit 100, :out "Reading package lists...\nBuilding dependency tree...\nReading state information...\nPackage oracle-java8-installer is not available, but is referred to by another package.\nThis may mean that the package is missing, has been obsoleted, or\nis only available from another source\n\n", :err "E: Package 'oracle-java8-installer' has no installation candidate\n", :host "n1", :action {:cmd "sudo -S -u root bash -c \"cd /; env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes oracle-java8-installer\"", :in "root\n"}} {:type :jepsen.control/nonzero-exit, :cmd "sudo -S -u root bash -c \"cd /; env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes oracle-java8-installer\"", :exit 100, :out "Reading package lists...\nBuilding dependency tree...\nReading state information...\nPackage oracle-java8-installer is not available, but is referred to by another package.\nThis may mean that the package is missing, has been obsoleted, or\nis only available from another source\n\n", :err "E: Package 'oracle-java8-installer' has no installation candidate\n", :host "n1", :action {:cmd "sudo -S -u root bash -c \"cd /; env DEBIAN_FRONTEND=noninteractive apt-get install -y --force-yes oracle-java8-installer\"", :in "root\n"}}
```
