### PR TITLE
Ignite: support Persistance and ScanQuery (works like SQL inside) 

### DIFF
--- a/ignite/resources/apache-ignite.xml.tmpl
+++ b/ignite/resources/apache-ignite.xml.tmpl
@@ -75,6 +75,28 @@
                 </property>
             </bean>
         </property>
+
+        <property name="autoActivationEnabled" value="##pds##"/>
+
+        <!-- Enabling Apache Ignite native persistence. -->
+        <property name="dataStorageConfiguration">
+            <bean class="org.apache.ignite.configuration.DataStorageConfiguration">
+                <property name="defaultDataRegionConfiguration">
+                    <bean class="org.apache.ignite.configuration.DataRegionConfiguration">
+                        <property name="persistenceEnabled" value="true"/>
+                        <property name="metricsEnabled" value="true"/>
+                        <property name="metricsRateTimeInterval" value="1000"/>
+                    </bean>
+                </property>
+                <property name="pageSize" value="#{4*1024}"/>
+                <property name="checkpointFrequency" value="60000"/>
+                <property name="walMode" value="LOG_ONLY"/>
+                <property name="metricsEnabled" value="true"/>
+                <property name="metricsRateTimeInterval" value="1000"/>
+                <property name="walCompactionEnabled" value="true"/>
+                <property name="concurrencyLevel" value="560"/>
+            </bean>
+        </property>
     </bean>
     <bean parent="ignite.cfg"/>
 </beans>

--- a/ignite/resources/apache-ignite.xml.tmpl
+++ b/ignite/resources/apache-ignite.xml.tmpl
@@ -76,14 +76,14 @@
             </bean>
         </property>
 
-        <property name="autoActivationEnabled" value="##pds##"/>
+        <property name="autoActivationEnabled" value="false"/>
 
         <!-- Enabling Apache Ignite native persistence. -->
         <property name="dataStorageConfiguration">
             <bean class="org.apache.ignite.configuration.DataStorageConfiguration">
                 <property name="defaultDataRegionConfiguration">
                     <bean class="org.apache.ignite.configuration.DataRegionConfiguration">
-                        <property name="persistenceEnabled" value="true"/>
+                        <property name="persistenceEnabled" value="##pds##"/>
                         <property name="metricsEnabled" value="true"/>
                         <property name="metricsRateTimeInterval" value="1000"/>
                     </bean>

--- a/ignite/run_test.sh
+++ b/ignite/run_test.sh
@@ -15,4 +15,5 @@ lein run test \
   --backups 3 \
   --os noop \
   --nemesis noop \
-  --version 2.7.0
+  --version 2.7.0 \
+  --pds true

--- a/ignite/src/jepsen/ignite.clj
+++ b/ignite/src/jepsen/ignite.clj
@@ -72,7 +72,9 @@
     (= true (try (c/exec :egrep (c/lit (str "\"Topology snapshot \\[.*?, servers\\=" (count (:nodes test)) ",\"")) logfile)
       (catch Exception e true))) (do
         (info node "Waiting for cluster started")
-        (Thread/sleep 3000))))
+        (Thread/sleep 3000)))
+  (c/cd server-dir
+     (c/exec "bin/control.sh"  (str "--activate --host " node))))
 
 (defn stop!
   "Shuts down server."
@@ -89,22 +91,23 @@
     (c/exec :rm :-rf server-dir))
   (info node "Apache Ignite nuked"))
 
-(defn configure [addresses client-mode]
+(defn configure [addresses client-mode pds]
   "Creates a config file."
   (-> (slurp "resources/apache-ignite.xml.tmpl")
     (str/replace "##addresses##" (clojure.string/join "\n" (map #(str "\t<value>" % ":47500..47509</value>") addresses)))
     (str/replace "##instancename##" (str (UUID/randomUUID)))
-    (str/replace "##clientmode##" (str client-mode))))
+    (str/replace "##clientmode##" (str client-mode))
+    (str/replace "##pds##" pds)))
 
-(defn configure-server [addresses node]
+(defn configure-server [addresses node pds]
   "Creates a server config file and uploads it to the given node."
-  (c/exec :echo (configure addresses false) :> (str server-dir "server-ignite-" node ".xml")))
+  (c/exec :echo (configure addresses false pds) :> (str server-dir "server-ignite-" node ".xml")))
 
-(defn configure-client [addresses]
+(defn configure-client [addresses pds]
   "Creates a client config file."
   (let [config-file (File/createTempFile "jepsen-ignite-config" ".xml")
         config-file-path (.getCanonicalPath config-file)]
-    (spit config-file-path (configure addresses true))
+    (spit config-file-path (configure addresses true pds))
      config-file))
 
 (defn db
@@ -121,7 +124,7 @@
           (c/exec :chown :-R (str user ":" user) server-dir)
          )
        (c/sudo user
-        (configure-server (:nodes test) node)
+        (configure-server (:nodes test) node (:pds test))
         (start! node test)
         (await-cluster-started node test))
          )
@@ -183,4 +186,5 @@
                     :debian debian/os
                     :noop jepsen.os/noop)
      :db      (db (:version options))
+     :pds     (:pds options)
      :nemesis (:nemesis options)}))

--- a/ignite/src/jepsen/ignite.clj
+++ b/ignite/src/jepsen/ignite.clj
@@ -63,7 +63,7 @@
   [node test]
   (info node "Starting server node")
     (c/cd server-dir
-      (c/exec "bin/ignite.sh" (str server-dir "server-ignite-" node ".xml") :-v (c/lit (str ">" logfile " 2>&1 &")))))
+      (c/exec "bin/ignite.sh" (str server-dir "server-ignite-" node ".xml") :-v (c/lit (str ">>" logfile " 2>&1 &")))))
 
 (defn await-cluster-started
   "Waits for the grid cluster started."
@@ -73,6 +73,13 @@
       (catch Exception e true))) (do
         (info node "Waiting for cluster started")
         (Thread/sleep 3000))))
+
+(defn stop!
+  "Shuts down server."
+  [node test]
+  (c/su
+    (meh (c/exec :pkill :-9 :-f "org.apache.ignite.startup.cmdline.CommandLineStartup")))
+  (info node "Apache Ignite stopped"))
 
 (defn nuke!
   "Shuts down server and destroys all data."

--- a/ignite/src/jepsen/ignite/bank.clj
+++ b/ignite/src/jepsen/ignite/bank.clj
@@ -58,7 +58,7 @@
    transaction-config]
   client/Client
   (open! [this test node]
-    (let [ignite-config-file (ignite/configure-client (:nodes test))
+    (let [ignite-config-file (ignite/configure-client (:nodes test) (:pds test))
           conn               (Bank. (.getCanonicalPath ignite-config-file))]
       (.setAccountCache
        conn

--- a/ignite/src/jepsen/ignite/nemesis.clj
+++ b/ignite/src/jepsen/ignite/nemesis.clj
@@ -1,0 +1,17 @@
+(ns jepsen.ignite.nemesis
+  "Apache Ignite nenesis"
+  (:refer-clojure :exclude [test])
+  (:require [clojure.tools.logging :refer :all]
+            [jepsen [ignite :as ignite]
+                    [nemesis :as nemesis]]))
+
+(def kill-node
+  "Kills random node"
+  (nemesis/node-start-stopper
+    rand-nth
+    (fn start [test node] (ignite/stop! node test))
+    (fn stop [test node] (ignite/start! node test))))
+
+(def partition-random-halves
+  (nemesis/partition-random-halves))
+

--- a/ignite/src/jepsen/ignite/register.clj
+++ b/ignite/src/jepsen/ignite/register.clj
@@ -12,8 +12,11 @@
   (:import (org.apache.ignite Ignition IgniteCache)
            (clojure.lang ExceptionInfo)))
 
+(def key "k")
+
 (defn r   [_ _] {:type :invoke, :f :read, :value nil})
-(defn w   [_ _] {:type :invoke, :f :write, :value (rand-int 1000)})
+(defn w   [_ _] {:type :invoke, :f :write, :value (rand-int 5)})
+(defn cas [_ _] {:type :invoke, :f :cas, :value [(rand-int 5) (rand-int 5)]})
 
 (defrecord Client [conn cache config]
   client/Client
@@ -28,16 +31,18 @@
   (invoke! [_ test op]
     (try
       (case (:f op)
-        :read (let [value (.get cache "k")]
+        :read (let [value (.get cache key)]
                 (assoc op :type :ok :value value))
-        :write (do (.put cache "k" (:value op))
-                (assoc op :type :ok)))))
+        :write (do (.put cache key (:value op))
+                (assoc op :type :ok))
+        :cas (let [[value value'] (:value op)]
+                (assoc op :type (if (.replace cache key value value') :ok :fail))))))
 
   (teardown! [this test]
     (.delete config))
 
   (close! [_ test]
-    (.stop conn true)))
+    (.close conn)))
 
 (defn test
   [opts]
@@ -49,5 +54,5 @@
                     (checker/compose
                       {:linearizable (checker/linearizable {:model (model/cas-register)})
                        :timeline  (timeline/html)}))
-       :generator (ignite/generator [r w] (:time-limit opts))}
+       :generator (ignite/generator [r w cas] (:time-limit opts))}
       opts)))

--- a/ignite/src/jepsen/ignite/register.clj
+++ b/ignite/src/jepsen/ignite/register.clj
@@ -21,7 +21,7 @@
 (defrecord Client [conn cache config]
   client/Client
   (open! [this test node]
-    (let [config (ignite/configure-client (:nodes test))
+    (let [config (ignite/configure-client (:nodes test) (:pds test))
       conn (Ignition/start (.getCanonicalPath config))
       cache (.getOrCreateCache conn "JepsenCache")]
       (assoc this :conn conn :cache cache :config config)))

--- a/ignite/src/jepsen/ignite/runner.clj
+++ b/ignite/src/jepsen/ignite/runner.clj
@@ -4,10 +4,10 @@
   (:require [clojure.pprint :refer [pprint]]
             [clojure.tools.logging :refer :all]
             [jepsen.cli :as jc]
-            [jepsen.nemesis :as nemesis]
             [jepsen.core :as jepsen]
             [jepsen.ignite  [register :as register]
-                            [bank     :as bank]])
+                            [bank     :as bank]
+                            [nemesis  :as nemesis]])
   (:import (org.apache.ignite.cache CacheMode CacheAtomicityMode CacheWriteSynchronizationMode)
            (org.apache.ignite.transactions TransactionConcurrency TransactionIsolation)))
 
@@ -45,8 +45,9 @@
    "REPEATABLE_READ" TransactionIsolation/REPEATABLE_READ})
 
 (def nemesis-types
-  {"noop"                   nemesis/noop
-  "partition-random-halves" nemesis/partition-random-halves})
+  {"noop"                   jepsen.nemesis/noop
+  "partition-random-halves" nemesis/partition-random-halves
+  "kill-node"               nemesis/kill-node})
 
 (def opt-spec
   "Command line options for tools.cli"
@@ -101,7 +102,7 @@
     :validate [#{:centos :debian :noop} "One of `centos` or `debian` or 'noop'"]]
    ["-nemesis" "--nemesis Nemesis"
     "What Nemesis to use"
-    :default nemesis/noop
+    :default jepsen.nemesis/noop
     :parse-fn nemesis-types
     :validate [identity (jc/one-of nemesis-types)]]])
 

--- a/ignite/src/jepsen/ignite/runner.clj
+++ b/ignite/src/jepsen/ignite/runner.clj
@@ -100,6 +100,10 @@
     :default  :noop
     :parse-fn keyword
     :validate [#{:centos :debian :noop} "One of `centos` or `debian` or 'noop'"]]
+   ["-p" "--pds NAME" "Persistence Data Store."
+    :default  :false
+    :parse-fn str
+    :validate [#{"true" "false"} "One of `true` or `false`"]]
    ["-nemesis" "--nemesis Nemesis"
     "What Nemesis to use"
     :default jepsen.nemesis/noop


### PR DESCRIPTION
Added Persistence Data Store support
Added one process Nemeside (kill node)
Added CAS operation to register test (small fix)

Added new "get all accounts" realisation in bank test. (I still thinking how to provide an opportunity to choose which function to use, without changing the test code)
ScanQuery works like SQL inside. In this mode Bank test pases only on TRANSACT_SNAPSHOT caches (MVCC)