### PR TITLE
tidb: add schedule nemesis

### DIFF
--- a/tidb/resources/pd.conf
+++ b/tidb/resources/pd.conf
@@ -3,5 +3,42 @@ election-interval="300ms"
 lease=1
 tso-save-interval="1s"
 
+[log]
+level = "info"
+
+[schedule]
+# max-merge-region-size = 0
+# max-merge-region-keys = 0
+split-merge-interval = "5s"
+max-snapshot-count = 3
+max-pending-peer-count = 16
+max-store-down-time = "100h"
+leader-schedule-limit = 4
+region-schedule-limit = 4
+replica-schedule-limit = 8
+merge-schedule-limit = 8
+tolerant-size-ratio = 5.0
+
+# customized schedulers, the format is as below
+# if empty, it will use balance-leader, balance-region, hot-region as default
+# [[schedule.schedulers]]
+# type = "random-merge"
+# args = []
+# [[schedule.schedulers]]
+# type = "shuffle-region"
+# args = []
+# [[schedule.schedulers]]
+# type = "shuffle-leader"
+# args = []
+[[schedule.schedulers]]
+type = "balance-region"
+args = []
+[[schedule.schedulers]]
+type = "balance-leader"
+args = []
+[[schedule.schedulers]]
+type = "hot-region"
+args = []
+
 [replication]
 max-replicas=3

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -117,6 +117,9 @@
     :pause-pd
     :pause-kv
     :pause-db
+    :shuffle-leader
+    :shuffle-region
+    :random-merge
     :clock-skew
     ; Special-case generators
     :restart-kv-without-pd})
@@ -160,6 +163,18 @@
                :color       "#A6A0E9"
                :start       #{:pause-db}
                :stop        #{:resume-db}}
+              {:name        "shuffle-leader"
+               :color       "#A6D0E9"
+               :start       #{:shuffle-leader}
+               :stop        #{:del-shuffle-leader}}
+              {:name        "shuffle-region"
+               :color       "#A6D0C9"
+               :start       #{:shuffle-region}
+               :stop        #{:del-shuffle-region}}
+              {:name        "random-merge"
+               :color       "#A6D0A9"
+               :start       #{:random-merge}
+               :stop        #{:del-random-merge}}
               {:name        "partition"
                :color       "#A0C8E9"
                :start       #{:start-partition}

--- a/tidb/src/tidb/core.clj
+++ b/tidb/src/tidb/core.clj
@@ -117,6 +117,7 @@
     :pause-pd
     :pause-kv
     :pause-db
+    :schedules
     :shuffle-leader
     :shuffle-region
     :random-merge
@@ -133,8 +134,11 @@
         [:pause]
         [:clock-skew]
         [:partitions]
+        [:shuffle-leader]
+        [:shuffle-region]
+        [:random-merge]
         ; Combined
-        [:kill :pause :clock-skew :partitions]]
+        [:kill :pause :clock-skew :partitions :schedules]]
        (map (fn [faults] (zipmap faults (repeat true))))))
 
 (def plot-spec

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -12,7 +12,9 @@
             [tidb.sql :as sql]))
 
 (def tidb-dir       "/opt/tidb")
+(def tidb-bin-dir   "/opt/tidb/bin")
 (def pd-bin         "pd-server")
+(def pdctl-bin      "pd-ctl")
 (def kv-bin         "tikv-server")
 (def db-bin         "tidb-server")
 (def pd-config-file (str tidb-dir "/pd.conf"))
@@ -205,6 +207,7 @@
       (info node "installing TiDB")
       (info (tarball-url test))
       (cu/install-archive! (tarball-url test) tidb-dir)
+      (c/exec :ln :-s (str tidb-bin-dir "/" pdctl-bin) (str "/bin/" pdctl-bin))
       (info "Syncing disks to avoid slow fsync on db start")
       (c/exec :sync))))
 

--- a/tidb/src/tidb/nemesis.clj
+++ b/tidb/src/tidb/nemesis.clj
@@ -275,7 +275,7 @@
     (:pause n) (assoc :pause-pd true
                       :pause-kv true
                       :pause-db true)
-    (:bad-sched n) (assoc :shuffle-leader true
+    (:schedules n) (assoc :shuffle-leader true
                           :shuffle-region true
                           :random-merge true)
     (:partitions n) (assoc :partition-one true


### PR DESCRIPTION
Add some special schedulers these are only used in tests, very helpful for testing Multi-Raft implementation.

- shuffle-leader: randomly transfer raft leader between different peers,
- shuffle-region: randomly add peer to different tikv,
- random-merge: randomly merge two regions into one.
