### PR TITLE
Tutorial: fix some typos

### DIFF
--- a/doc/tutorial/04-checker.md
+++ b/doc/tutorial/04-checker.md
@@ -91,8 +91,8 @@ returned.
 To analyze the history, we'll specify a `:checker` for the test, and provide a
 `:model` to specify how the system *should* behave.
 `checker/linearizable` uses the Knossos linearizability checker to verify that
-every operation appears take place atomically between its invocation and
-completion. The linearizable checker requires a model and to specify a specific
+every operation appears to take place atomically between its invocation and
+completion. The linearizable checker requires a model and to specify a particular
 algorithm which we pass to it in an options map.
 
 ```clj

--- a/doc/tutorial/05-nemesis.md
+++ b/doc/tutorial/05-nemesis.md
@@ -40,10 +40,10 @@ it receives a `:start` op, and heals the network when it receives a `:stop`.
           :db         (db "v3.1.5")
           :client     (Client. nil)
           :nemesis    (nemesis/partition-random-halves)
-          :model      (model/cas-register)
           :checker    (checker/compose
                         {:perf      (checker/perf)
-                         :linear    (checker/linearizable)
+                         :linear    (checker/linearizable {:model     (model/cas-register)
+                                                           :algorithm :linear})
                          :timeline  (timeline/html)})
           :generator  (->> (gen/mix [r w cas])
                            (gen/stagger 1)

--- a/doc/tutorial/07-parameters.md
+++ b/doc/tutorial/07-parameters.md
@@ -27,7 +27,7 @@ Now, let's pass that option specification to the CLI:
             args)
 ```
 
-If we re-run our test with `lein run test -q ...", we'll see a new `:quorum` option in our test map:
+If we re-run our test with `lein run test -q ...`, we'll see a new `:quorum` option in our test map:
 
 ```clj
 10:02:42.532 [main] INFO  jepsen.cli - Test options:
@@ -179,7 +179,6 @@ as a rate per second, and change our hardcoded limit on each key's generator to 
             :db         (db "v3.1.5")
             :client     (Client. nil)
             :nemesis    (nemesis/partition-random-halves)
-            :model      (model/cas-register)
             :checker    (checker/compose
                           {:perf  (checker/perf)
                            :indep (independent/checker

--- a/doc/tutorial/08-set.md
+++ b/doc/tutorial/08-set.md
@@ -316,10 +316,11 @@ generator, based on the set workload.
             :db         (db "v3.1.5")
             :client     (Client. nil)
             :nemesis    (nemesis/partition-random-halves)
-            :model      (model/cas-register)
             :checker    (checker/compose
                           {:perf      (checker/perf)
-                           :linear    (independent/checker (checker/linearizable))
+                           :linear    (independent/checker (checker/linearizable 
+                                                             {:model     (model/cas-register)
+                                                              :algorithm :linear}))
                            :timeline  (independent/checker (timeline/html))})
             :generator  (->> (independent/concurrent-generator
                                10


### PR DESCRIPTION
Sorry, I missed some typos when I was updating the tutorial to 0.1.13. This fixes some of them.