### PR TITLE
tidb: collect slow log

### DIFF
--- a/tidb/resources/tidb.conf
+++ b/tidb/resources/tidb.conf
@@ -4,6 +4,9 @@ lease = "5s"
 # One table per region (default: true)
 split-table = true
 
+[log]
+slow-query-file = "slow.log"
+
 [tikv-client]
 
 # Max time for commit command, must be twice bigger than raft election timeout.

--- a/tidb/src/tidb/db.clj
+++ b/tidb/src/tidb/db.clj
@@ -32,6 +32,7 @@
 (def kv-data-dir    (str tidb-dir "/data/kv"))
 (def db-config-file (str tidb-dir "/db.conf"))
 (def db-log-file    (str tidb-dir "/db.log"))
+(def db-slow-file   (str tidb-dir "/slow.log"))
 (def db-stdout      (str tidb-dir "/db.stdout"))
 (def db-pid-file    (str tidb-dir "/db.pid"))
 
@@ -386,6 +387,7 @@
     db/LogFiles
     (log-files [_ test node]
       [db-log-file
+       db-slow-file
        db-stdout
        kv-log-file
        kv-stdout


### PR DESCRIPTION
TiDB logs slow query in a slow-log file, it contains some useful information for debugging.