### PR TITLE
During clock-nemesis setup, stop ntp in addition to ntpd

### DIFF
--- a/jepsen/src/jepsen/nemesis/time.clj
+++ b/jepsen/src/jepsen/nemesis/time.clj
@@ -101,6 +101,8 @@
       (c/with-test-nodes test (install!))
       ; Try to stop ntpd service in case it is present and running.
       (c/with-test-nodes test
+        (try (c/su (c/exec :service :ntp :stop))
+             (catch RuntimeException e))
         (try (c/su (c/exec :service :ntpd :stop))
              (catch RuntimeException e)))
       (reset-time! test)


### PR DESCRIPTION
Hey there!
We're using Jepsen 0.1.14 and it looks like NTP daemon service is sometimes named `ntp`:
```
root@n1:~# sudo service ntpd
ntpd: unrecognized service

root@n1:~# sudo service ntp
Usage: /etc/init.d/ntp {start|stop|restart|try-restart|force-reload|status}

root@n1:~# sudo service ntp stop
[ ok ] Stopping NTP server: ntpd.
```
Without stopping `ntp` we're getting this:
```
WARN [2019-06-13 12:57:46,954] main - jepsen.core Test crashed!
clojure.lang.ExceptionInfo: Command exited with non-zero status 1 on node n1:
sudo -S -u root bash -c "cd /; ntpdate -b time.google.com"

STDIN:
null

STDOUT:


STDERR:
13 Jun 12:57:34 ntpdate[10563]: the NTP socket is in use, exiting

	at slingshot.support$stack_trace.invoke(support.clj:201) ~[knossos-0.3.4.jar:na]
	at jepsen.control$throw_on_nonzero_exit.invokeStatic(control.clj:126) ~[jepsen-0.1.14.jar:na]
	at jepsen.control$throw_on_nonzero_exit.invoke(control.clj:121) ~[jepsen-0.1.14.jar:na]
	at jepsen.control$exec_STAR_.invokeStatic(control.clj:170) ~[jepsen-0.1.14.jar:na]
	at jepsen.control$exec_STAR_.doInvoke(control.clj:167) ~[jepsen-0.1.14.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invoke(core.clj:660) ~[clojure-1.10.0.jar:na]
	at jepsen.control$exec.invokeStatic(control.clj:186) ~[jepsen-0.1.14.jar:na]
	at jepsen.control$exec.doInvoke(control.clj:180) ~[jepsen-0.1.14.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:436) ~[clojure-1.10.0.jar:na]
	at jepsen.nemesis.time$reset_time_BANG_.invokeStatic(time.clj:74) ~[na:na]
	at jepsen.nemesis.time$reset_time_BANG_.invoke(time.clj:71) ~[na:na]
	at jepsen.nemesis.time$reset_time_BANG_$fn__3674.invoke(time.clj:75) ~[na:na]
	at jepsen.control$on_nodes$fn__2918.invoke(control.clj:391) ~[jepsen-0.1.14.jar:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:154) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.0.jar:na]
	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973) ~[clojure-1.10.0.jar:na]
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:669) ~[clojure-1.10.0.jar:na]
	at clojure.core$bound_fn_STAR_$fn__5734.doInvoke(core.clj:2003) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.0.jar:na]
	at dom_top.core$real_pmap_helper$build_thread__214$fn__215.invoke(core.clj:146) ~[jepsen-0.1.14.jar:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.0.jar:na]
	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973) ~[clojure-1.10.0.jar:na]
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:425) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:156) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:132) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:669) ~[clojure-1.10.0.jar:na]
	at clojure.core$bound_fn_STAR_$fn__5734.doInvoke(core.clj:2003) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.run(AFn.java:22) ~[clojure-1.10.0.jar:na]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_171]
```
Version info:
```
alex@alex-debian-jessie:~/code/jepsen/yugabyte$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux 8.11 (jessie)
Release:	8.11
Codename:	jessie

root@n1:~# apt-cache policy ntpdate
ntpdate:
  Installed: 1:4.2.6.p5+dfsg-7+deb8u2
  Candidate: 1:4.2.6.p5+dfsg-7+deb8u2
  Version table:
 *** 1:4.2.6.p5+dfsg-7+deb8u2 0
        500 http://http.debian.net/debian/ jessie/main amd64 Packages
        100 /var/lib/dpkg/status
```