### PR TITLE
Adapt servers. Downgrader compose file version 3.4

### DIFF
--- a/docker/control/init.sh
+++ b/docker/control/init.sh
@@ -9,14 +9,18 @@ if [ ! -f ~/.ssh/known_hosts ]; then
     chmod 600 ~/.ssh/id_rsa
     echo $SSH_PUBLIC_KEY > ~/.ssh/id_rsa.pub
     echo > ~/.ssh/known_hosts
-    for f in $(seq 1 5);do
-	ssh-keyscan -t rsa n$f >> ~/.ssh/known_hosts
-    done
+    #for f in $(seq 1 5);do
+    #	ssh-keyscan -t rsa n$f >> ~/.ssh/known_hosts
+    #done
+fi
+
+if [ ! -f ~/.ssh/config ]; then
+   echo 'StrictHostKeyChecking no' > ~/.ssh/config
 fi
 
 # TODO: assert that SSH_PRIVATE_KEY==~/.ssh/id_rsa
 
-cat <<EOF 
+cat <<EOF
 Welcome to Jepsen on Docker
 ===========================
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.4'
 services:
   control:
     volumes:

--- a/docker/docker-compose.ubuntu.yml
+++ b/docker/docker-compose.ubuntu.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.4'
 x-ubuntu:
   &ubuntu
   build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.4'
 x-node:
   &default-node
   build: ./node
@@ -8,6 +8,7 @@ x-node:
     - jepsen
 
 services:
+
   control:
     container_name: jepsen-control
     hostname: control

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -97,13 +97,13 @@ fi
 
 # Make sure folders referenced in control Dockerfile exist and don't contain leftover files
 rm -rf ./control/jepsen
-mkdir -p ./control/jepsen/jepsen
+mkdir -p ./control/jepsen
 # Copy the jepsen directory if we're not mounting the JEPSEN_ROOT
 if [ ! "$DEV" ]; then
     # Dockerfile does not allow `ADD ..`. So we need to copy it here in setup.
     INFO "Copying .. to control/jepsen"
     (
-        (cd ..; tar --exclude=./docker --exclude=./.git --exclude-ignore=.gitignore -cf - .)  | tar Cxf ./control/jepsen -
+        cd ..; tar zcf jepsen.tgz jepsen; mv jepsen.tgz docker/control/jepsen; cd docker/control/jepsen; tar xf jepsen.tgz; rm -f jepsen.tgz
     )
 fi
 


### PR DESCRIPTION
```client version 1.38 is too new. Maximum supported API version is 1.37```

Docker-compose yml file version 3.7 is only for desktop developers and is not for servers, so downgrader compose version 3.4 for server that adapt servers.


Signed-off-by: Xiaobo Tian <peterwillcn@gmail.com>