### PR TITLE
Fix compilation with JDK 12

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -27,9 +27,8 @@
   :main jepsen.cli
   :plugins [[lein-localrepo "0.5.4"]
             [lein-codox "0.10.3"]]
-  :jvm-opts ["-Xmx32g" "-XX:+UseConcMarkSweepGC" "-XX:+UseParNewGC"
-             "-XX:+CMSParallelRemarkEnabled" "-XX:+AggressiveOpts"
-             "-XX:+UseFastAccessorMethods" "-server"]
+  :jvm-opts ["-Xmx32g"
+             "-server"]
   :test-selectors {:default (fn [m]
                               (not (or (:integration m)
                                        (:logging m))))
@@ -39,9 +38,6 @@
           :source-uri "https://github.com/jepsen-io/jepsen/blob/{version}/jepsen/{filepath}#L{line}"
           :metadata {:doc/format :markdown}}
   :profiles {:uberjar {:aot :all}
-             :dev {:jvm-opts ["-Xmx32g" "-XX:+UseConcMarkSweepGC"
-                              "-XX:+UseParNewGC"
-                              "-XX:+CMSParallelRemarkEnabled"
-                              "-XX:+AggressiveOpts"
-                              "-XX:+UseFastAccessorMethods" "-server"
+             :dev {:jvm-opts ["-Xmx32g"
+                              "-server"
                               "-XX:-OmitStackTraceInFastThrow"]}})

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -14,7 +14,7 @@
                  [tea-time "1.0.1"]
                  [clj-ssh "0.5.14"]
                  [gnuplot "0.1.1"]
-                 [http-kit "2.1.18"]
+                 [http-kit "2.3.0"]
                  [ring "1.6.0-beta5"]
                  [hiccup "1.0.5"]
                  [metametadata/multiset "0.1.1"]


### PR DESCRIPTION
JDK 12 removed couple of deprecated JDK option, using these options now results into JDK failure. 
To be able to use JDK 12, also version of http-kit needs to be updated.