### PR TITLE
jepsen.control: Add a `Controller` protocol

### DIFF
--- a/jepsen/src/jepsen/core.clj
+++ b/jepsen/src/jepsen/core.clj
@@ -496,7 +496,7 @@
   :logging    Logging options; see jepsen.store/start-logging!
   :os         The operating system; given by the OS protocol
   :db         The database to configure: given by the DB protocol
-  :controller The remote controller: given by the Controller protocol
+  :remote     The remote to use for control actions: given by the Remote protocol
   :client     A client for the database
   :nemesis    A client for failures
   :generator  A generator of operations to apply to the DB
@@ -554,7 +554,7 @@
                           :active-histories (atom #{}))
               _    (store/start-logging! test)
               _    (info "Running test:\n" (with-out-str (pprint test)))
-              test (control/with-controller (:controller test)
+              test (control/with-remote (:remote test)
                      (control/with-ssh (:ssh test)
                        (with-resources [sessions
                                         (bound-fn* control/session)

--- a/jepsen/src/jepsen/store.clj
+++ b/jepsen/src/jepsen/store.clj
@@ -156,7 +156,7 @@
 
 (def default-nonserializable-keys
   "What keys in a test can't be serialized to disk, by default?"
-  #{:db :os :net :client :checker :nemesis :generator :model :controller})
+  #{:db :os :net :client :checker :nemesis :generator :model :remote})
 
 (defn nonserializable-keys
   "What keys in a test can't be serialized to disk? The union of default

--- a/jepsen/src/jepsen/tests.clj
+++ b/jepsen/src/jepsen/tests.clj
@@ -14,16 +14,16 @@
   "Boring test stub.
   Typically used as a basis for writing more complex tests.
   "
-  {:nodes      ["n1" "n2" "n3" "n4" "n5"]
-   :name       "noop"
-   :os         os/noop
-   :db         db/noop
-   :net        net/iptables
-   :controller control/ssh
-   :client     client/noop
-   :nemesis    nemesis/noop
-   :generator  gen/void
-   :checker    (checker/unbridled-optimism)})
+  {:nodes     ["n1" "n2" "n3" "n4" "n5"]
+   :name      "noop"
+   :os        os/noop
+   :db        db/noop
+   :net       net/iptables
+   :remote    control/ssh
+   :client    client/noop
+   :nemesis   nemesis/noop
+   :generator gen/void
+   :checker   (checker/unbridled-optimism)})
 
 (defn atom-db
   "Wraps an atom as a database."


### PR DESCRIPTION
In my internal environment I can't use SSH with the built-in `clj-ssh`, but most of the functions in the control module are still useful to me. In particular, `jepsen.control.util/install-archive!` and `jepsen.nemesis/partition-random-halves` (among others) are still quite relevant.

Rather than re-implementing all of that stuff, I found it useful to add a `Controller` protocol to `jepsen.control`. The protocol provides a small abstraction over the existing `clj-ssh` code, and every test gets an implementation based on `clj-ssh` by default.

With this protocol in place I was able to implement that protocol myself, and run Jepsen tests on my internal infrastructure.

Does this seem like a useful addition? If so, is this in the right ballpark of implementation?