### PR TITLE
[Jepsen] Update version to 0.1.16-SNAPSHOT

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.1.15"
+(defproject jepsen "0.1.16-SNAPSHOT"
   :description "Distributed systems testing framework."
   :url         "https://jepsen.io"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Just a small tweak the project version to `0.1.16-SNAPSHOT`, now that `0.1.15` has been released.

I didn't update any of the specific database tests since it looks like they maybe version Jepsen individually? Let me know if you want me to update those too...