### PR TITLE
Add options for passing in username and password for wget and cached-wget

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -105,6 +105,11 @@
   "Directory for caching files from the web."
   (str tmp-dir-base "/wget-cache"))
 
+(defn encode
+  "base64 encode a given string and return the encoded string in utf8"
+  [s]
+  (String. (b64/encode (.getBytes s)) "UTF-8"))
+
 (defn cached-wget!
   "Downloads a string URL to the Jepsen wget cache directory, and returns the
   full local filename as a string. Skips if the file already exists. Local
@@ -122,7 +127,7 @@
   ([url]
    (cached-wget! url {:force? false}))
   ([url opts]
-   (let [encoded-url (String. (b64/encode (.getBytes url)) "UTF-8")
+   (let [encoded-url (encode url)
          dest-file   (str wget-cache-dir "/" encoded-url)
          wget-opts   (if (empty? (:user? opts)) 
                        (concat std-wget-opts [:-O dest-file])

--- a/jepsen/test/jepsen/control/util_test.clj
+++ b/jepsen/test/jepsen/control/util_test.clj
@@ -1,0 +1,51 @@
+(ns jepsen.control.util-test
+  (:require [jepsen.control :as c]
+            [slingshot.slingshot :refer [try+ throw+]]
+            [jepsen.control.util :as util]
+            [clojure.test :refer :all]
+            [clojure.java.io :as io]))
+
+(defn assert-file-exists
+  "Asserts that a file exists at a given destination"
+  [dest file]
+  (is (= (util/exists? (io/file dest file)) true)))
+
+(defn assert-file-cached
+  "Asserts that a file from a url was downloaded and cached in the wget-cache-dir"
+  [url]
+  (assert-file-exists util/wget-cache-dir (util/encode url)))
+
+(deftest ^:integration install-archive-test
+  (testing "install-archive works without auth credentials"
+    (c/with-ssh {}
+      (c/on "n1"
+        (let [dest "/tmp/test"
+              url "https://storage.googleapis.com/etcd/v3.0.0/etcd-v3.0.0-linux-amd64.tar.gz"]
+          (util/install-archive! (str url) dest {:force? true})
+          (assert-file-exists dest "etcd")
+          (assert-file-cached url)))))
+  
+  (testing "install-archive works with auth credentials"
+    (let [dest "/tmp/test"
+          url "ftp://speedtest.tele2.net/1KB.zip"]
+      (c/with-ssh {}
+        (c/on "n1"
+          (try+
+            (util/install-archive! (str url) dest {:force? true :user? "anonymous" :pw? "anonymous"})
+          (catch Object m
+            ; The ZIP we download from the test server is not a real archive
+            ; so unzip returns an exit code of 9 with a specific message 
+            ; that must be in the exception if the download was successful
+            (is (= (:exit m) 9))
+            (.contains (:err m) "End-of-central-directory signature not found")
+            (assert-file-cached url))))))))
+
+(deftest ^:integration cached-wget-test
+  (testing "cached-wget works with and without auth credentials"
+    (c/with-ssh {}
+      (c/on "n1"
+        (let [url "ftp://speedtest.tele2.net/1KB.zip"]
+          (util/cached-wget! (str url) {:force? true})
+          (assert-file-cached url)
+          (util/cached-wget! (str url) {:force? true :user? "anonymous" :pw? "anonymous"})
+          (assert-file-cached url))))))


### PR DESCRIPTION
Hello,

We have a use case for downloading packages from a private repository, so it is necessary to pass `--user` and `--pasword` flags to `wget`. I could not find a way to do this currently, and I could not find any examples where authentication is used in the existing examples.

Thanks for this awesome project!