### PR TITLE
FaunaDB: Update for changes to 2.8 and beyond

### DIFF
--- a/faunadb/project.clj
+++ b/faunadb/project.clj
@@ -7,5 +7,4 @@
                  [clj-yaml "0.4.0"]
                  [jepsen "0.1.14"]
                  [clj-wallhack "1.0.1"]
-                 [com.faunadb/faunadb-java "2.5.6"]
-                 [com.faunadb/faunadb-java-dsl "2.5.6"]])
+                 [com.faunadb/faunadb-java "2.8.0"]])

--- a/faunadb/src/jepsen/faunadb/auto.clj
+++ b/faunadb/src/jepsen/faunadb/auto.clj
@@ -128,7 +128,8 @@
     (info node (str/join ["creating " (:replicas test) " replicas"]))
     (when (< 1 (:replica-count @(:topology test)))
       (c/exec :faunadb-admin
-              :update-replication
+              :update-replica
+              :data+log
               (topo/replicas @(:topology test))))
     (when (:wait-for-convergence test)
       (wait-for-replication node)
@@ -434,12 +435,8 @@
                    :network_broadcast_address      node
                    :network_host_id                node
                    :network_listen_address         ip}
-                  (when (topo/manual-log-config? test)
-                    {:storage_transaction_log_nodes (topo/log-configuration
-                                                       topo)})
                   (when (:accelerate-indexes test)
                     {:accelerate_indexes true})
-
                   (when (:datadog-api-key test)
                     {:stats_host "localhost"
                      :stats_port 8125})))

--- a/faunadb/src/jepsen/faunadb/auto.clj
+++ b/faunadb/src/jepsen/faunadb/auto.clj
@@ -460,17 +460,8 @@
     (setup! [_ test node]
       (install! test)
       (configure! test @(:topology test) node)
-      (when (:clear-cache test)
-        (clear-cache!))
-      (if (cache-valid? test)
-        (unpack-cache!)
-        ; We have to go through the whole setup process, then we'll build a
-        ; cache for next time
-        (do (start! test node)
-            (init! test (topo/replica @(:topology test) node) node)
-            (stop! test node)
-            (build-cache! test)))
-      (start! test node))
+      (start! test node)
+      (init! test (topo/replica @(:topology test) node) node))
 
     (teardown! [_ test node]
       (info node "tearing down FaunaDB")

--- a/faunadb/src/jepsen/faunadb/client.clj
+++ b/faunadb/src/jepsen/faunadb/client.clj
@@ -22,8 +22,7 @@
                                      Fn$UnescapedArray)
            (com.fasterxml.jackson.databind.node NullNode)
            (java.io IOException)
-           (java.time Instant)
-           (org.asynchttpclient Dsl))
+           (java.time Instant))
   (:require [clojure.string :as str]
             [clojure.pprint :refer [pprint]]
             [clojure.tools.logging :refer [warn info]]
@@ -51,13 +50,6 @@
   ([node path]
    (.build
      (doto (FaunaClient/builder)
-       (.withHttpClient
-         (Dsl/asyncHttpClient
-           (.. (Dsl/config)
-               ; By default this chooses cores * 2 and blows out process limits
-               (setIoThreadsCount 1)
-               (setMaxRequestRetry 0)
-               (build))))
        (.withEndpoint (str "http://" node ":8443" path))
        (.withSecret root-key)))))
 

--- a/faunadb/src/jepsen/faunadb/topology.clj
+++ b/faunadb/src/jepsen/faunadb/topology.clj
@@ -4,12 +4,6 @@
   (:require [clojure.set :as set]
             [jepsen.util :refer [rand-nth-empty]]))
 
-(defn manual-log-config?
-  "Does the version being tested require manual log configuration?"
-  [test]
-  (let [v (:version test)]
-    (boolean (re-find #"2\.5\.\d+" v))))
-
 (defn replica-name
   "Constructs a replica name for a given replica number."
   [n]
@@ -31,16 +25,6 @@
                  (fn [i node]
                    {:node    node
                     :state   :active
-                    ; We assign initial log partitions to the first r nodes,
-                    ; and stripe nodes mod r over replicas:
-                    ; => (map #(quot % 3) (range 10))
-                    ; (0 0 0 1 1 1 2 2 2 3)
-                    ; => (map #(mod % 3) (range 10))
-                    ; (0 1 2 0 1 2 0 1 2 0)
-                    ; Log parts are now optional as of 2.6.0, but we generate
-                    ; them for testing 2.5.4 and 2.5.5.
-                    :log-part (when (manual-log-config? test)
-                                (quot i (:replicas test)))
                     :replica (replica-name (mod i (:replicas test)))})))})
 
 ; Node accessors


### PR DESCRIPTION
* Replica name is now set via the command line when initialising or joining a cluster.
* Initial topology reconciliation has gotten faster, no need to cache.
* Use the newer 2.8 client which does away with AsyncHttpClient and is more considerate of machine resources.