### PR TITLE
fix expected value be disordered after previous read nil in internal

### DIFF
--- a/jepsen/src/jepsen/tests/cycle/append.clj
+++ b/jepsen/src/jepsen/tests/cycle/append.clj
@@ -163,7 +163,7 @@
        (reduce (fn [[state error] [f k v :as mop]]
                  (case f
                    :append [(assoc! state k
-                                    (conj (get state k [unknown-prefix]) v))
+                                    (conj (or (get state k [unknown-prefix]) []) v))
                             error]
                    :r      (let [s (get state k)]
                              (if (and s ; We have an expected state


### PR DESCRIPTION
fix expected value be disordered after previous read `nil` in internal consistent check

### question:

our test failed by this result~ 

```
{:perf {:latency-graph {:valid? true},
        :rate-graph {:valid? true},
        :valid? true},
 :clock-skew {:valid? true},
 :workload {:valid? false,
            :anomaly-types (:internal),
            :anomalies {:internal ({:op {:type :ok,
                                         :f :txn,
                                         :value [[:r 232 nil]
                                                 [:append 232 3]
                                                 [:append 232 4]
                                                 [:r 232 [3 4]]],
                                         :process 1,
                                         :time 26111762334,
                                         :index 6006},
                                    :mop [:r 232 [3 4]],
                                    :expected (4 3)})}},
 :valid? false}
```

It seems `[:r 232 nil]` will put `nil` into state at https://github.com/jepsen-io/jepsen/blob/master/jepsen/src/jepsen/tests/cycle/append.clj#L184

so following  ` [:append 232 3]` will get `nil` instead of `[unknown-prefix]`

```
                   :append [(assoc! state k
                                    (conj (get state k [unknown-prefix]) v))
```

`(conj nil)` will make the reverse result `(4 3)`

### try to fix

assoc an empty vector instead of nil at append.clj#L184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jepsen-io/jepsen/424)
<!-- Reviewable:end -->
