### PR TITLE
Make it possible to expose ports with docker compose.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,6 +6,8 @@ x-node:
   privileged: true
   networks:
     - jepsen
+  ports:
+    - ${JEPSEN_PORT:-22}
 
 services:
   control:


### PR DESCRIPTION
For example `JEPSEN_PORT=8000 ./up.sh`, this is useful when debugging
as it lets you inspect the database from your host (you might want
to move your teardown function to happen before setup, so that your
databases stay around after the test finish).

I couldn't figure out how to not expose anything if `JEPSEN_PORT`
isn't set, so by default port 22 is exposed. I think that's fine as
ssh is always running. Unbelievable how the same people who talk about
"infrastructure as code" don't support if-statements.