### PR TITLE
jepsen.os.debian: truncate arch while checking installed packages

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -52,6 +52,7 @@
          (map (fn [line] (str/split line #"\s+")))
          (filter #(= "install" (second %)))
          (map first)
+         (map (fn [p] (str/replace p #":amd64|:i386" {":amd64" "" ":i386" ""})))
          set)))
 
 (defn uninstall!


### PR DESCRIPTION
Package names reported by `dpkg --get-selections` can contain
architecture at the end of package name, such as `package:amd64`
or `package:i386`.

When `debian/install [:package]` is called, if package name contains
arch, then installed package name does not match and Jepsen tries
to install package on every run.

Fixes #420