### PR TITLE
Make docker-compose work as non-root.

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -26,9 +26,9 @@ RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
 ARG uid
 ARG gid
 
-RUN groupadd -g $gid kyle \
-	&& useradd -m -u $uid -g kyle kyle
-USER kyle
+RUN groupadd -g $gid jepsen \
+	&& useradd -m -u $uid -g jepsen jepsen
+USER jepsen
 
 # without --dev flag up.sh copies jepsen to these subfolders
 # with --dev flag they are empty until mounted
@@ -36,8 +36,8 @@ COPY jepsen/jepsen /jepsen/jepsen/
 RUN if [ -f /jepsen/jepsen/project.clj ]; then cd /jepsen/jepsen && lein install; fi
 COPY jepsen /jepsen/
 
-ADD --chown=kyle:kyle ./bashrc /home/kyle/.bashrc
-ADD --chown=kyle:kyle ./init.sh /home/kyle/init.sh
-RUN chmod +x /home/kyle/init.sh
+ADD --chown=jepsen:jepsen ./bashrc /home/jepsen/.bashrc
+ADD --chown=jepsen:jepsen ./init.sh /home/jepsen/init.sh
+RUN chmod +x /home/jepsen/init.sh
 
-CMD /home/kyle/init.sh
+CMD /home/jepsen/init.sh

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -y -q update && \
     add-apt-repository ppa:openjdk-r/ppa && \
     apt-get -y -q update && \
     apt-get install -qqy \
-        dos2unix \
         openjdk-8-jdk \
         libjna-java \
         git \
@@ -24,15 +23,21 @@ RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
     chmod +x /usr/bin/lein && \
     lein self-install
 
+ARG uid
+ARG gid
+
+RUN groupadd -g $gid kyle \
+	&& useradd -m -u $uid -g kyle kyle
+USER kyle
+
 # without --dev flag up.sh copies jepsen to these subfolders
 # with --dev flag they are empty until mounted
 COPY jepsen/jepsen /jepsen/jepsen/
 RUN if [ -f /jepsen/jepsen/project.clj ]; then cd /jepsen/jepsen && lein install; fi
 COPY jepsen /jepsen/
 
-ADD ./bashrc /root/.bashrc
-ADD ./init.sh /init.sh
-RUN dos2unix /init.sh /root/.bashrc \
-    && chmod +x /init.sh
+ADD --chown=kyle:kyle ./bashrc /home/kyle/.bashrc
+ADD --chown=kyle:kyle ./init.sh /home/kyle/init.sh
+RUN chmod +x /home/kyle/init.sh
 
-CMD /init.sh
+CMD /home/kyle/init.sh

--- a/docker/control/bashrc
+++ b/docker/control/bashrc
@@ -1,5 +1,5 @@
 eval $(ssh-agent) &> /dev/null
-ssh-add /root/.ssh/id_rsa &> /dev/null
+ssh-add "${HOME}/.ssh/id_rsa" &> /dev/null
 
 cat <<EOF
 Welcome to Jepsen on Docker

--- a/docker/control/init.sh
+++ b/docker/control/init.sh
@@ -9,14 +9,14 @@ if [ ! -f ~/.ssh/known_hosts ]; then
     chmod 600 ~/.ssh/id_rsa
     echo $SSH_PUBLIC_KEY > ~/.ssh/id_rsa.pub
     echo > ~/.ssh/known_hosts
-    for f in $(seq 1 5);do
-	ssh-keyscan -t rsa n$f >> ~/.ssh/known_hosts
+    for f in $(seq 1 5); do
+        ssh-keyscan -t rsa n$f >> ~/.ssh/known_hosts
     done
 fi
 
 # TODO: assert that SSH_PRIVATE_KEY==~/.ssh/id_rsa
 
-cat <<EOF 
+cat <<EOF
 Welcome to Jepsen on Docker
 ===========================
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       - jepsen
     user: $USER
     volumes:
-      - ~/.m2/repository/:/home/kyle/.m2/repository/
-      - ~/.lein/:/home/kyle/.lein/
+      - ~/.m2/repository/:/home/jepsen/.m2/repository/
+      - ~/.lein/:/home/jepsen/.lein/
   n1:
     << : *default-node
     container_name: jepsen-n1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -20,6 +20,10 @@ services:
       - "8080"
     networks:
       - jepsen
+    user: $USER
+    volumes:
+      - ~/.m2/repository/:/home/kyle/.m2/repository/
+      - ~/.lein/:/home/kyle/.lein/
   n1:
     << : *default-node
     container_name: jepsen-n1

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -137,17 +137,18 @@ exists docker-compose ||
 
 INFO "Running \`docker-compose build\`"
 # shellcheck disable=SC2086
-docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} build
+docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} build \
+               --build-arg uid="$(id -u)" --build-arg gid="$(id -g)"
 
 INFO "Running \`docker-compose up\`"
-if [ "${RUN_AS_DAEMON}" -eq 1 ]; then
+if [ "${RUN_AS_DAEMON}" ]; then
     # shellcheck disable=SC2086
-    docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} up -d
+    USER=$(id -u) docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} up -d
     INFO "All containers started, run \`docker ps\` to view"
 else
     INFO "Please run \`docker exec -it jepsen-control bash\` in another terminal to proceed"
     # shellcheck disable=SC2086
-    docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} up
+    USER=$(id -u) docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} up
 fi
 
 popd

--- a/docker/up.sh
+++ b/docker/up.sh
@@ -141,7 +141,7 @@ docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} build \
                --build-arg uid="$(id -u)" --build-arg gid="$(id -g)"
 
 INFO "Running \`docker-compose up\`"
-if [ "${RUN_AS_DAEMON}" ]; then
+if [ "${RUN_AS_DAEMON}" -eq 1 ]; then
     # shellcheck disable=SC2086
     USER=$(id -u) docker-compose -f docker-compose.yml ${COMPOSE} ${DEV} up -d
     INFO "All containers started, run \`docker ps\` to view"


### PR DESCRIPTION
I'm trying to make the docker-compose stuff work as non-root in order to be able to mount my ~/.m2 so that I can use locally installed libraries and not have to fetch the dependencies all time and at the same time not have docker write as root into that directory.

That part works. However sshing doesn't:

```
clojure.lang.ExceptionInfo: throw+: {:dir "/", :private-key-path nil, :password "root", :username "root", :type :jepsen.cont
rol/session-error, :port 22, :strict-host-key-checking false, :host nil, :sudo nil, :dummy nil, :message "Error opening SSH
session. Verify username, password, and node hostnames are correct.", :session nil}
        at slingshot.support$stack_trace.invoke(support.clj:201) ~[knossos-0.3.6.jar:na]
        at jepsen.control.SSHRemote$fn__3007.invoke(control.clj:342) ~[jepsen-0.1.17.jar:na]
        at jepsen.control.SSHRemote.connect(control.clj:339) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$session$fn__3022.invoke(control.clj:370) ~[jepsen-0.1.17.jar:na]
        at jepsen.reconnect$open_BANG_$fn__2784.invoke(reconnect.clj:59) ~[jepsen-0.1.17.jar:na]
        at jepsen.reconnect$open_BANG_.invokeStatic(reconnect.clj:57) ~[jepsen-0.1.17.jar:na]
        at jepsen.reconnect$open_BANG_.invoke(reconnect.clj:54) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$session.invokeStatic(control.clj:369) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$session.invoke(control.clj:365) ~[jepsen-0.1.17.jar:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:154) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:669) ~[clojure-1.10.1.jar:na]
        at clojure.core$bound_fn_STAR_$fn__5749.doInvoke(core.clj:2003) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invoke(core.clj:660) ~[clojure-1.10.1.jar:na]
        at jepsen.util$fcatch$wrapper__2044.doInvoke(util.clj:37) ~[jepsen-0.1.17.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.1.jar:na]
        at dom_top.core$real_pmap_helper$build_thread__214$fn__215.invoke(core.clj:146) ~[jepsen-0.1.17.jar:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:425) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:156) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.applyTo(RestFn.java:132) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:669) ~[clojure-1.10.1.jar:na]
        at clojure.core$bound_fn_STAR_$fn__5749.doInvoke(core.clj:2003) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.run(AFn.java:22) ~[clojure-1.10.1.jar:na]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_232]
Caused by: com.jcraft.jsch.JSchException: Auth fail
        at com.jcraft.jsch.Session.connect(Session.java:512) ~[jsch-0.1.53.jar:na]
        at com.jcraft.jsch.Session.connect(Session.java:183) ~[jsch-0.1.53.jar:na]
        at clj_ssh.ssh$fn__2480.invokeStatic(ssh.clj:118) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh$fn__2480.invoke(ssh.clj:115) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh.protocols$fn__2438$G__2405__2447.invoke(protocols.clj:4) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh$connect.invokeStatic(ssh.clj:401) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh$connect.invoke(ssh.clj:397) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$clj_ssh_session.invokeStatic(control.clj:331) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$clj_ssh_session.invoke(control.clj:317) ~[jepsen-0.1.17.jar:na]
        at jepsen.control.SSHRemote$fn__3007.invoke(control.clj:340) ~[jepsen-0.1.17.jar:na]
        ... 34 common frames omitted


        ... 34 common frames omitted
ERROR [2020-02-26 10:46:44,676] main - jepsen.cli Oh jeez, I'm sorry, Jepsen broke. Here's why:
clojure.lang.ExceptionInfo: throw+: {:dir "/", :private-key-path nil, :password "root", :username "root", :type :jepsen.control/session-error, :port 22, :strict-host-key-checking false, :host nil, :sudo nil, :dummy nil, :message "Error opening SSH
session. Verify username, password, and node hostnames are correct.", :session nil}
        at slingshot.support$stack_trace.invoke(support.clj:201) ~[knossos-0.3.6.jar:na]
        at jepsen.control.SSHRemote$fn__3007.invoke(control.clj:342) ~[jepsen-0.1.17.jar:na]
        at jepsen.control.SSHRemote.connect(control.clj:339) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$session$fn__3022.invoke(control.clj:370) ~[jepsen-0.1.17.jar:na]
        at jepsen.reconnect$open_BANG_$fn__2784.invoke(reconnect.clj:59) ~[jepsen-0.1.17.jar:na]
        at jepsen.reconnect$open_BANG_.invokeStatic(reconnect.clj:57) ~[jepsen-0.1.17.jar:na]
        at jepsen.reconnect$open_BANG_.invoke(reconnect.clj:54) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$session.invokeStatic(control.clj:369) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$session.invoke(control.clj:365) ~[jepsen-0.1.17.jar:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:154) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:669) ~[clojure-1.10.1.jar:na]
        at clojure.core$bound_fn_STAR_$fn__5749.doInvoke(core.clj:2003) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invoke(core.clj:660) ~[clojure-1.10.1.jar:na]
        at jepsen.util$fcatch$wrapper__2044.doInvoke(util.clj:37) ~[jepsen-0.1.17.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.1.jar:na]
        at dom_top.core$real_pmap_helper$build_thread__214$fn__215.invoke(core.clj:146) ~[jepsen-0.1.17.jar:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:665) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:425) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.applyToHelper(AFn.java:156) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.applyTo(RestFn.java:132) ~[clojure-1.10.1.jar:na]
        at clojure.core$apply.invokeStatic(core.clj:669) ~[clojure-1.10.1.jar:na]
        at clojure.core$bound_fn_STAR_$fn__5749.doInvoke(core.clj:2003) ~[clojure-1.10.1.jar:na]
        at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.1.jar:na]
        at clojure.lang.AFn.run(AFn.java:22) ~[clojure-1.10.1.jar:na]
        at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_232]
Caused by: com.jcraft.jsch.JSchException: Auth fail
        at com.jcraft.jsch.Session.connect(Session.java:512) ~[jsch-0.1.53.jar:na]
        at com.jcraft.jsch.Session.connect(Session.java:183) ~[jsch-0.1.53.jar:na]
        at clj_ssh.ssh$fn__2480.invokeStatic(ssh.clj:118) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh$fn__2480.invoke(ssh.clj:115) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh.protocols$fn__2438$G__2405__2447.invoke(protocols.clj:4) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh$connect.invokeStatic(ssh.clj:401) ~[jepsen-0.1.17.jar:na]
        at clj_ssh.ssh$connect.invoke(ssh.clj:397) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$clj_ssh_session.invokeStatic(control.clj:331) ~[jepsen-0.1.17.jar:na]
        at jepsen.control$clj_ssh_session.invoke(control.clj:317) ~[jepsen-0.1.17.jar:na]
        at jepsen.control.SSHRemote$fn__3007.invoke(control.clj:340) ~[jepsen-0.1.17.jar:na]
        ... 34 common frames omitted
```

If I do `docker exec -it jepsen-control bash` and then `ssh -o StrictHostKeyChecking=no root@n1 hostname` it works though.

I can't think of anything that my change introduced that would cause this to break, any hints?