### PR TITLE
Stevana/clock targets

### DIFF
--- a/jepsen/src/jepsen/nemesis/combined.clj
+++ b/jepsen/src/jepsen/nemesis/combined.clj
@@ -15,11 +15,11 @@
   which allow us to start, kill, pause, and resume processes."
   (:require [clojure.tools.logging :refer [info warn]]
             [jepsen [control :as c]
-             [db :as db]
-             [generator :as gen]
-             [nemesis :as n]
-             [util :as util :refer [majority
-                                    random-nonempty-subset]]]
+                    [db :as db]
+                    [generator :as gen]
+                    [nemesis :as n]
+                    [util :as util :refer [majority
+                                           random-nonempty-subset]]]
             [jepsen.generator.pure :as gen.pure]
             [jepsen.nemesis.time :as nt]))
 
@@ -113,11 +113,11 @@
 
         ; Flip-flop generators
         kill-start   (gen/stateful+pure
-                      (gen/flip-flop kill start)
-                      (gen.pure/flip-flop kill (repeat start)))
+                       (gen/flip-flop kill start)
+                       (gen.pure/flip-flop kill (repeat start)))
         pause-resume (gen/stateful+pure
-                      (gen/flip-flop pause resume)
-                      (gen.pure/flip-flop pause (repeat resume)))
+                       (gen/flip-flop pause resume)
+                       (gen.pure/flip-flop pause (repeat resume)))
 
         ; Automatically generate nemesis failure modes based on what the DB
         ; supports.
@@ -130,8 +130,8 @@
                  kill?  (conj start))]
     {:generator       (gen/mix modes)
      :final-generator (gen/stateful+pure
-                       (gen/seq final)
-                       final)}))
+                        (gen/seq final)
+                        final)}))
 
 (defn db-package
   "A nemesis and generator package for acting on a single DB. Options are from
@@ -140,10 +140,10 @@
   (when (some #{:kill :pause} (:faults opts))
     (let [{:keys [generator final-generator]} (db-generators opts)
           generator (gen/stateful+pure
-                     (gen/delay (:interval opts default-interval)
-                                generator)
-                     (gen.pure/delay-til (:interval opts default-interval)
-                                         generator))
+                      (gen/delay (:interval opts default-interval)
+                                 generator)
+                      (gen.pure/delay-til (:interval opts default-interval)
+                                          generator))
           nemesis   (db-nemesis (:db opts))]
       {:generator       generator
        :final-generator final-generator
@@ -226,14 +226,14 @@
                            :value (rand-nth targets)})
           stop  {:type :info, :f :stop-partition, :value nil}
           gen   (gen/stateful+pure
-                 (->> (gen/flip-flop start stop)
-                      (gen/delay (:interval opts default-interval)))
-                 (->> (gen.pure/flip-flop start (repeat stop))
-                      (gen.pure/delay-til (:interval opts default-interval))))]
+                  (->> (gen/flip-flop start stop)
+                       (gen/delay (:interval opts default-interval)))
+                  (->> (gen.pure/flip-flop start (repeat stop))
+                       (gen.pure/delay-til (:interval opts default-interval))))]
       {:generator       gen
        :final-generator (gen/stateful+pure
-                         (gen/once stop)
-                         stop)
+                          (gen/once stop)
+                          stop)
        :nemesis         (partition-nemesis db)
        :perf            #{{:name  "partition"
                            :start #{:start-partition}
@@ -255,35 +255,35 @@
           targets (fn [test] (db-nodes test db
                                        (some-> target-specs seq rand-nth)))
           clock-gen (gen/stateful+pure
-                     (gen/phases
-                      (gen/once {:type :info, :f :check-offsets})
-                      ;; Use a random subset of nodes, specificed by
-                      ;; `targets-specs`, as targets in the generators.
-                      (gen/mix [(nt/reset-gen-select  targets)
-                                (nt/bump-gen-select   targets)
-                                (nt/strobe-gen-select targets)]))
-                     (gen.pure/phases
-                      {:type :info, :f :check-offsets}
-                      (gen.pure/mix [(nt/reset-gen-select  targets)
-                                     (nt/bump-gen-select   targets)
-                                     (nt/strobe-gen-select targets)])))
+                      (gen/phases
+                       (gen/once {:type :info, :f :check-offsets})
+                       ;; Use a random subset of nodes, specificed by
+                       ;; `targets-specs`, as targets in the generators.
+                       (gen/mix [(nt/reset-gen-select  targets)
+                                 (nt/bump-gen-select   targets)
+                                 (nt/strobe-gen-select targets)]))
+                      (gen.pure/phases
+                       {:type :info, :f :check-offsets}
+                       (gen.pure/mix [(nt/reset-gen-select  targets)
+                                      (nt/bump-gen-select   targets)
+                                      (nt/strobe-gen-select targets)])))
           gen (gen/stateful+pure
-               (->> clock-gen
-                    (gen/f-map {:reset          :reset-clock
-                                :check-offsets  :check-clock-offsets
-                                :strobe         :strobe-clock
-                                :bump           :bump-clock})
-                    (gen/delay (:interval opts default-interval)))
-               (->> clock-gen
-                    (gen.pure/f-map {:reset          :reset-clock
-                                     :check-offsets  :check-clock-offsets
-                                     :strobe         :strobe-clock
-                                     :bump           :bump-clock})
-                    (gen.pure/delay-til (:interval opts default-interval))))]
+                (->> clock-gen
+                     (gen/f-map {:reset          :reset-clock
+                                 :check-offsets  :check-clock-offsets
+                                 :strobe         :strobe-clock
+                                 :bump           :bump-clock})
+                     (gen/delay (:interval opts default-interval)))
+                (->> clock-gen
+                     (gen.pure/f-map {:reset          :reset-clock
+                                      :check-offsets  :check-clock-offsets
+                                      :strobe         :strobe-clock
+                                      :bump           :bump-clock})
+                     (gen.pure/delay-til (:interval opts default-interval))))]
       {:generator         gen
        :final-generator   (gen/stateful+pure
-                           (gen/once {:type :info, :f :reset-clock})
-                           {:type :info, :f :reset-clock})
+                            (gen/once {:type :info, :f :reset-clock})
+                            {:type :info, :f :reset-clock})
        :nemesis           nemesis
        :perf              #{{:name  "clock"
                              :start #{:bump-clock}
@@ -297,11 +297,11 @@
   sequentially."
   [packages]
   {:generator       (gen/stateful+pure
-                     (gen/mix (map :generator packages))
-                     (gen.pure/mix (map :generator packages)))
+                      (gen/mix (map :generator packages))
+                      (gen.pure/mix (map :generator packages)))
    :final-generator (gen/stateful+pure
-                     (apply gen/concat (keep :final-generator packages))
-                     (apply concat (keep :final-generator packages)))
+                      (apply gen/concat (keep :final-generator packages))
+                      (apply concat (keep :final-generator packages)))
    :nemesis         (n/compose (map :nemesis packages))
    :perf            (reduce into #{} (map :perf packages))})
 

--- a/jepsen/src/jepsen/nemesis/combined.clj
+++ b/jepsen/src/jepsen/nemesis/combined.clj
@@ -15,11 +15,11 @@
   which allow us to start, kill, pause, and resume processes."
   (:require [clojure.tools.logging :refer [info warn]]
             [jepsen [control :as c]
-                    [db :as db]
-                    [generator :as gen]
-                    [nemesis :as n]
-                    [util :as util :refer [majority
-                                           random-nonempty-subset]]]
+             [db :as db]
+             [generator :as gen]
+             [nemesis :as n]
+             [util :as util :refer [majority
+                                    random-nonempty-subset]]]
             [jepsen.generator.pure :as gen.pure]
             [jepsen.nemesis.time :as nt]))
 
@@ -113,11 +113,11 @@
 
         ; Flip-flop generators
         kill-start   (gen/stateful+pure
-                       (gen/flip-flop kill start)
-                       (gen.pure/flip-flop kill (repeat start)))
+                      (gen/flip-flop kill start)
+                      (gen.pure/flip-flop kill (repeat start)))
         pause-resume (gen/stateful+pure
-                       (gen/flip-flop pause resume)
-                       (gen.pure/flip-flop pause (repeat resume)))
+                      (gen/flip-flop pause resume)
+                      (gen.pure/flip-flop pause (repeat resume)))
 
         ; Automatically generate nemesis failure modes based on what the DB
         ; supports.
@@ -130,8 +130,8 @@
                  kill?  (conj start))]
     {:generator       (gen/mix modes)
      :final-generator (gen/stateful+pure
-                        (gen/seq final)
-                        final)}))
+                       (gen/seq final)
+                       final)}))
 
 (defn db-package
   "A nemesis and generator package for acting on a single DB. Options are from
@@ -140,10 +140,10 @@
   (when (some #{:kill :pause} (:faults opts))
     (let [{:keys [generator final-generator]} (db-generators opts)
           generator (gen/stateful+pure
-                      (gen/delay (:interval opts default-interval)
-                                 generator)
-                      (gen.pure/delay-til (:interval opts default-interval)
-                                          generator))
+                     (gen/delay (:interval opts default-interval)
+                                generator)
+                     (gen.pure/delay-til (:interval opts default-interval)
+                                         generator))
           nemesis   (db-nemesis (:db opts))]
       {:generator       generator
        :final-generator final-generator
@@ -226,14 +226,14 @@
                            :value (rand-nth targets)})
           stop  {:type :info, :f :stop-partition, :value nil}
           gen   (gen/stateful+pure
-                  (->> (gen/flip-flop start stop)
-                       (gen/delay (:interval opts default-interval)))
-                  (->> (gen.pure/flip-flop start (repeat stop))
-                       (gen.pure/delay-til (:interval opts default-interval))))]
+                 (->> (gen/flip-flop start stop)
+                      (gen/delay (:interval opts default-interval)))
+                 (->> (gen.pure/flip-flop start (repeat stop))
+                      (gen.pure/delay-til (:interval opts default-interval))))]
       {:generator       gen
        :final-generator (gen/stateful+pure
-                          (gen/once stop)
-                          stop)
+                         (gen/once stop)
+                         stop)
        :nemesis         (partition-nemesis db)
        :perf            #{{:name  "partition"
                            :start #{:start-partition}
@@ -250,24 +250,40 @@
                                :strobe-clock          :strobe
                                :bump-clock            :bump}
                               (nt/clock-nemesis)})
-          gen     (gen/stateful+pure
-                    (->> (nt/clock-gen)
-                         (gen/f-map {:reset          :reset-clock
+          db (:db opts)
+          target-specs (:targets (:clock opts) (node-specs db))
+          targets (fn [test] (db-nodes test db
+                                       (some-> target-specs seq rand-nth)))
+          clock-gen (gen/stateful+pure
+                     (gen/phases
+                      (gen/once {:type :info, :f :check-offsets})
+                      ;; Use a random subset of nodes, specificed by
+                      ;; `targets-specs`, as targets in the generators.
+                      (gen/mix [(nt/reset-gen-select  targets)
+                                (nt/bump-gen-select   targets)
+                                (nt/strobe-gen-select targets)]))
+                     (gen.pure/phases
+                      {:type :info, :f :check-offsets}
+                      (gen.pure/mix [(nt/reset-gen-select  targets)
+                                     (nt/bump-gen-select   targets)
+                                     (nt/strobe-gen-select targets)])))
+          gen (gen/stateful+pure
+               (->> clock-gen
+                    (gen/f-map {:reset          :reset-clock
+                                :check-offsets  :check-clock-offsets
+                                :strobe         :strobe-clock
+                                :bump           :bump-clock})
+                    (gen/delay (:interval opts default-interval)))
+               (->> clock-gen
+                    (gen.pure/f-map {:reset          :reset-clock
                                      :check-offsets  :check-clock-offsets
                                      :strobe         :strobe-clock
                                      :bump           :bump-clock})
-                         (gen/delay (:interval opts default-interval)))
-                    (->> (nt/clock-gen)
-                         (gen.pure/f-map {:reset          :reset-clock
-                                     :check-offsets  :check-clock-offsets
-                                     :strobe         :strobe-clock
-                                     :bump           :bump-clock})
-                         (gen.pure/delay-til
-                           (:interval opts default-interval))))]
+                    (gen.pure/delay-til (:interval opts default-interval))))]
       {:generator         gen
        :final-generator   (gen/stateful+pure
-                            (gen/once {:type :info, :f :reset-clock})
-                            {:type :info, :f :reset-clock})
+                           (gen/once {:type :info, :f :reset-clock})
+                           {:type :info, :f :reset-clock})
        :nemesis           nemesis
        :perf              #{{:name  "clock"
                              :start #{:bump-clock}
@@ -281,11 +297,11 @@
   sequentially."
   [packages]
   {:generator       (gen/stateful+pure
-                      (gen/mix (map :generator packages))
-                      (gen.pure/mix (map :generator packages)))
+                     (gen/mix (map :generator packages))
+                     (gen.pure/mix (map :generator packages)))
    :final-generator (gen/stateful+pure
-                      (apply gen/concat (keep :final-generator packages))
-                      (apply concat (keep :final-generator packages)))
+                     (apply gen/concat (keep :final-generator packages))
+                     (apply concat (keep :final-generator packages)))
    :nemesis         (n/compose (map :nemesis packages))
    :perf            (reduce into #{} (map :perf packages))})
 

--- a/jepsen/src/jepsen/tests/causal_reverse.clj
+++ b/jepsen/src/jepsen/tests/causal_reverse.clj
@@ -123,6 +123,6 @@
                       ; re-use the same write generator for each distinct key,
                       ; but if it *did* and relied on that behavior, this will
                       ; break.
-                      (->> (gen.pure/mix [reads writes]
+                      (->> (gen.pure/mix [reads writes])
                            (gen.pure/stagger 1/100)
-                           (gen/limit (:per-key-limit opts 500))))))))})
+                           (gen/limit (:per-key-limit opts 500)))))))})


### PR DESCRIPTION
Second try. Changes since last time:

  * Fixed problem with broken compilation;
  * Updated to use new pure generator api.

I tried testing the code on the `etcd` repo using lein checkouts, but `etcd` doesn't compile anymore because some stuff in `tests.cycle` have been moved to `elle`?

Also sorry about the whitespace changes, I have the habit of hitting `SPC m =` and having CIDER reformat the buffer and it doesn't seem to agree with your formatting style (I thought in Lisp-land code formatting was as solved problem?). Or do you use a different formatter/settings? I'm happy to revert it if it annoys you?