### PR TITLE
docker: export JEPSEN_ROOT again

### DIFF
--- a/docker/up.sh
+++ b/docker/up.sh
@@ -53,6 +53,7 @@ do
         --dev)
             if [ ! "$JEPSEN_ROOT" ]; then
                 JEPSEN_ROOT="$(cd ../ && pwd)"
+                export JEPSEN_ROOT
                 INFO "JEPSEN_ROOT is not set, defaulting to: $JEPSEN_ROOT"
             fi
             INFO "Running docker-compose with dev config"


### PR DESCRIPTION
Export `JEPSEN_ROOT` again as it's required by `docker-compose.dev.yml`.
Fixes GH #465