### PR TITLE
Tutorial: bump jepsen version to 0.2.0

### DIFF
--- a/doc/tutorial/01-scaffolding.md
+++ b/doc/tutorial/01-scaffolding.md
@@ -39,7 +39,7 @@ Verschlimmbesserung: a library for talking to etcd.
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :main jepsen.etcdemo
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [jepsen "0.1.13"]
+                 [jepsen "0.2.0"]
                  [verschlimmbesserung "0.1.3"]])
 ```
 


### PR DESCRIPTION
Bump to 0.2.0 so as to avoid the missing java.xml.bind issue.

cf. https://github.com/jepsen-io/jepsen/issues/474