### PR TITLE
Adding a first simplistic k8s remote, similar to Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ bench/**
 */timeline.html
 */resources/datomic/download-key
 */resources/datomic/riak-transactor.properties
-/.nrepl-port
+*/.nrepl-port
 .idea
 *.iml
 jepsen/doc

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.2.2-SNAPSHOT"
+(defproject jepsen "0.2.1-SNAPSHOT"
   :description "Distributed systems testing framework."
   :url         "https://jepsen.io"
   :license {:name "Eclipse Public License"

--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -1,4 +1,4 @@
-(defproject jepsen "0.2.0"
+(defproject jepsen "0.2.1"
   :description "Distributed systems testing framework."
   :url         "https://jepsen.io"
   :license {:name "Eclipse Public License"

--- a/jepsen/src/jepsen/control/k8s.clj
+++ b/jepsen/src/jepsen/control/k8s.clj
@@ -107,5 +107,4 @@
              (str "kubectl get pods " context " " namespace
                   " | tail -n +2 "
                   " | awk '{print $1}'"))]
-    (info (str "" res))
     (lazy-seq (split-lines (trim (:out res))))))

--- a/jepsen/src/jepsen/control/k8s.clj
+++ b/jepsen/src/jepsen/control/k8s.clj
@@ -92,8 +92,9 @@
   (download! [this remote-paths local-path _rest]
     (cp-from context namespace (:pod-name this) remote-paths local-path)))
 
-(def k8s
-  "A remote that does things via `kubectl exec` and `kubectl cp`."
+(defn k8s
+  "Returns a remote that does things via `kubectl exec` and `kubectl cp`, in the default context and namespacd."
+  []
   (->K8sRemote nil nil))
 
 (defn list-pods

--- a/jepsen/src/jepsen/control/k8s.clj
+++ b/jepsen/src/jepsen/control/k8s.clj
@@ -79,7 +79,6 @@
 (defrecord K8sRemote [context namespace]
   Remote
   (connect [this pod-name]
-    "Ignore host assuming direct kubectl cli access. Host parameter is misused to carry the name of the pod"
     (assoc this
            :context (or-parameter "context" context)
            :namespace (or-parameter "namespace" namespace)

--- a/jepsen/src/jepsen/control/k8s.clj
+++ b/jepsen/src/jepsen/control/k8s.clj
@@ -1,0 +1,112 @@
+(ns jepsen.control.k8s
+  "The recommended way is to use SSH to setup and teardown databases.
+  It's however sometimes conveniet to be able to setup and teardown
+  the databases using `kubectl` instead, which is what this namespace
+  helps you do. Use at your own risk, this is an unsupported way
+  of running Jepsen."
+  (:require [clojure.java.shell :refer [sh]]
+            [slingshot.slingshot :refer [throw+]]
+            [jepsen.control :as c]
+            [clojure.string :refer [split-lines, trim]]
+            [clojure.tools.logging :refer [info]])
+  (:import (jepsen.control Remote)))
+
+(defn exec
+  "Execute a shell command on a pod."
+  [context namespace pod-name {:keys [cmd] :as opts}]
+  (apply sh
+         "kubectl"
+         "exec"
+         (c/escape pod-name)
+         context
+         namespace
+         "--"
+         "sh"
+         "-c"
+         cmd
+         (if-let [in (:in opts)]
+           [:in in]
+           [])))
+
+(defn- path->pod
+  [pod-name path]
+  (str pod-name ":" path))
+
+(defn- unwrap-result
+  "Throws when shell returned with nonzero exit status."
+  [exc-type {:keys [exit] :as result}]
+  (if (zero? exit)
+    result
+    (throw+
+     (assoc result :type exc-type)
+     nil ; cause
+     "Command exited with non-zero status %d:\nSTDOUT:\n%s\n\nSTDERR:\n%s"
+     exit
+     (:out result)
+     (:err result))))
+
+(defn cp-to
+  "Copies files from the host to a pod filesystem."
+  [context namespace pod-name local-paths remote-path]
+  (doseq [local-path (flatten [local-paths])]
+    (->> (sh
+          "kubectl"
+          "cp"
+          (c/escape local-path)
+          (c/escape (path->pod pod-name remote-path))
+          context
+          namespace)
+         (unwrap-result ::copy-failed))))
+
+(defn cp-from
+  "Copies files from a pod filesystem to the host."
+  [context namespace pod-name remote-paths local-path]
+  (doseq [remote-path (flatten [remote-paths])]
+    (->> (sh
+          "kubectl"
+          "cp"
+          (c/escape (path->pod pod-name remote-path))
+          (c/escape local-path)
+          context
+          namespace)
+         (unwrap-result ::copy-failed))))
+
+(defn- or-parameter
+  "A helper function that encodes a parameter if present"
+  [p, v]
+  (if v (str "--" p "=" (c/escape v)) ""))
+
+(defrecord K8sRemote [context namespace]
+  Remote
+  (connect [this pod-name]
+    "Ignore host assuming direct kubectl cli access. Host parameter is misused to carry the name of the pod"
+    (assoc this
+           :context (or-parameter "context" context)
+           :namespace (or-parameter "namespace" namespace)
+           :pod-name pod-name))
+  (disconnect! [this]
+    (dissoc this :context :namespace :pod-name))
+  (execute! [this action]
+    (exec context namespace (:pod-name this) action))
+  (upload! [this local-paths remote-path _rest]
+    (cp-to context namespace (:pod-name this) local-paths remote-path))
+  (download! [this remote-paths local-path _rest]
+    (cp-from context namespace (:pod-name this) remote-paths local-path)))
+
+(def k8s
+  "A remote that does things via `kubectl exec` and `kubectl cp`."
+  (->K8sRemote nil nil))
+
+(defn list-pods
+  "A helper function to list all pods in a given context/namespace"
+  [context namespace]
+  (let [context (or-parameter "context" context)
+        namespace (or-parameter "namespace" namespace)
+        res (sh
+             "sh"
+             "-c"
+             (str "kubectl get pods " context " " namespace
+                  " | tail -n +2 "
+                  " | awk '{print $1}'"))]
+    (info (str "" res))
+    (lazy-seq (split-lines (trim (:out res))))))


### PR DESCRIPTION
When running the distributed system / store under test on k8s, it's better to use k8s' very own pod-based mechanisms to mess around with "nodes" rather than taking the regular ssh-to-node-or-container based approach.

I took the Docker remote as an example to introduce some very simplistic first k8s remote coming with this PR. I could have isolated this in my own jepsen tests, but thought it might be helpful for other people, and maybe it can grow since k8s is growing, and also all kids of systems get their footprint on it more and more.

Hope it's ok. Thanks.