### PR TITLE
fix some problems block the test.

### DIFF
--- a/yugabyte/project.clj
+++ b/yugabyte/project.clj
@@ -5,7 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [clj-http "3.8.0" :exclusions [commons-logging]]
-                 [jepsen "0.1.15"]
+                 [jepsen "0.1.16"]
                  [com.yugabyte/cassaforte "3.0.0-alpha2-yb-1"]
                  [org.clojure/java.jdbc "0.7.9"]
                  [org.postgresql/postgresql "42.2.5"]

--- a/yugabyte/src/yugabyte/auto.clj
+++ b/yugabyte/src/yugabyte/auto.clj
@@ -133,6 +133,7 @@
 
     (catch RuntimeException e
       (condp re-find (.getMessage e)
+        #"Could not locate the leader master"     (retry (dec tries))
         #"Timed out"                              (retry (dec tries))
         #"Leader not yet ready to serve requests" (retry (dec tries))
         (throw e)))))


### PR DESCRIPTION
- update jepsen version to 0.1.16, this version fix the dpkg problem.
- await-masters: add more error message to match.