### PR TITLE
Fix truncate nemesis lambda arguments

### DIFF
--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -528,7 +528,7 @@
       (let [plan (:value op)]
         (c/on-nodes test
                     (keys plan)
-                    (fn [node]
+                    (fn [_ node]
                       (let [{:keys [file drop]} (plan node)]
                         (assert (string? file))
                         (assert (integer? drop))


### PR DESCRIPTION
It seems like `control/on-nodes` function must accept lambda with two arguments.