### PR TITLE
Replace --force-yes option for apt-get(8)

### DIFF
--- a/jepsen/src/jepsen/os/debian.clj
+++ b/jepsen/src/jepsen/os/debian.clj
@@ -88,7 +88,12 @@
       (for [[pkg version] pkgs]
         (when (not= version (installed-version pkg))
           (info "Installing" pkg version)
-          (c/exec :env "DEBIAN_FRONTEND=noninteractive" :apt-get :install :-y :--force-yes
+          (c/exec :env "DEBIAN_FRONTEND=noninteractive" :apt-get :install
+                  :-y
+                  :--allow-unauthenticated
+                  :--allow-downgrades
+                  :--allow-remove-essential
+                  :--allow-change-held-packages
                   (str (name pkg) "=" version)))))
 
     ; Install any version
@@ -98,7 +103,13 @@
         (c/su
           (info "Installing" missing)
           (apply c/exec :env "DEBIAN_FRONTEND=noninteractive"
-                 :apt-get :install :-y :--force-yes missing))))))
+                 :apt-get :install
+                 :-y
+                 :--allow-unauthenticated
+                 :--allow-downgrades
+                 :--allow-remove-essential
+                 :--allow-change-held-packages
+                 missing))))))
 
 (defn add-key!
   "Receives an apt key from the given keyserver."


### PR DESCRIPTION
According to manual pages in Debian [1] and Ubuntu [2]
option --force-yes is deprecated and replaced by
--allow-unauthenticated, --allow-downgrades, --allow-remove-essential,
--allow-change-held-packages.

1. https://manpages.debian.org/buster/apt/apt-get.8.en.html
2. https://manpages.ubuntu.com/manpages/impish/en/man8/apt-get.8.html