### PR TITLE
Adding ALL capabilities to node containers

### DIFF
--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -15,7 +15,7 @@ x-node:
   networks:
     - jepsen
   cap_add:
-    - NET_ADMIN
+    - ALL
   ports:
     - ${JEPSEN_PORT:-22}
 


### PR DESCRIPTION
NETWORK_ADMIN capability is not sufficient for all nemesis. For example, clock_scrambler needs the capability to mess with the date. Adding ALL capabilities to node containers.