### PR TITLE
Update docker scripts for newer Docker/Debian

### DIFF
--- a/docker/bin/up
+++ b/docker/bin/up
@@ -9,15 +9,15 @@ set -o nounset
 # set -o xtrace
 
 ERROR() {
-    /bin/echo -e "\e[101m\e[97m[ERROR]\e[49m\e[39m" "$@"
+    printf "\e[101m\e[97m[ERROR]\e[49m\e[39m %s\n" "$@"
 }
 
 WARNING() {
-    /bin/echo -e "\e[101m\e[97m[WARNING]\e[49m\e[39m" "$@"
+    printf "\e[101m\e[97m[WARNING]\e[49m\e[39m %s\n" "$@"
 }
 
 INFO() {
-    /bin/echo -e "\e[104m\e[97m[INFO]\e[49m\e[39m" "$@"
+    printf "\e[104m\e[97m[INFO]\e[49m\e[39m %s\n" "$@"
 }
 
 exists() {
@@ -83,7 +83,9 @@ do
             ;;
     esac
 done
-set -- "${POSITIONAL[@]}" # restore positional parameters
+if [ "${#POSITIONAL[@]}" -gt 0 ]; then
+  set -- "${POSITIONAL[@]}" # restore positional parameters
+fi
 
 if [ "${HELP}" -eq 1 ]; then
     echo "Usage: $0 [OPTION]"

--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -10,10 +10,10 @@ x-node:
     - /run:size=100M
     - /run/lock:size=100M
   volumes:
-    - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
     - "jepsen-shared:/var/jepsen/shared"
   networks:
     - jepsen
+  privileged: true
   cap_add:
     - ALL
   ports:


### PR DESCRIPTION
- On Mac `/bin/echo -e "<control chars>"` prints out `-e <uninterpreted
  control chars>` to the terminal. This seems to happen in the latest
  Debian image too. Use `printf` for compatibility across both and
  proper colouration.
- Check that `POSITIONAL` has some elements before trying to `set` with
  it, to avoid `unbound variable` error with `set -o nounset`.
- Remove cgroup sharing from host, and make container privileged, to
  allow nodes to spin up with cgroupv2. Docker > 20.10 will
  automatically create a private cgroup slice in this case.