### PR TITLE
Fix Stolon test crash by passing missing test argument

### DIFF
--- a/stolon/src/jepsen/stolon/append.clj
+++ b/stolon/src/jepsen/stolon/append.clj
@@ -123,7 +123,7 @@
 (defrecord Client [node conn initialized?]
   client/Client
   (open! [this test node]
-    (let [c (c/open node)]
+    (let [c (c/open test node)]
       (assoc this
              :node          node
              :conn          c


### PR DESCRIPTION
**Description**

- Currently, the Jepsen `append` test case for Stolon crashes with a runtime error using the command `lein run test-all -w append --max-writes-per-key 4 --concurrency 50 -r 500 --isolation serializable --time-limit 60 --nemesis none --existing-postgres --node <host> --no-ssh --postgres-user <user> --postgres-password <password>`

```INFO [2022-02-16 09:59:49,500] main - jepsen.cli CLI options:
 {:postgres-user "db_team_internal",
 :max-txn-length 4,
 :isolation :serializable,
 :concurrency 50,
 :key-count 10,
 :existing-postgres true,
 :max-writes-per-key 4,
 :expected-consistency-model :serializable,
 :leave-db-running? false,
 :postgres-password
 "C-EyZ-v5BBFTtPLXu5rI9nPr8_IYz-eeBN3ApLrPtDW1DmVzpdr8qEcOIvIMM7gI",
 :etcd-version "3.4.3",
 :logging-json? false,
 :nemesis-interval 5,
 :ssh
 {:dummy? true,
  :username "root",
  :password "root",
  :strict-host-key-checking false,
  :private-key-path nil},
 :rate 500,
 :just-postgres false,
 :nemesis (),
 :nodes ["appsdb-staging.postgres.pdx.cfdata.org"],
 :test-count 1,
 :postgres-port 5432,
 :time-limit 60,
 :version "0.16.0",
 :workload :append}

INFO [2022-02-16 09:59:49,637] jepsen test runner - jepsen.core Running test:
 {:remote {:session nil},
 :postgres-user "db_team_internal",
 :max-txn-length 4,
 :isolation :serializable,
 :concurrency 50,
 :key-count 10,
 :existing-postgres true,
 :db
 #object[jepsen.db$reify__3425 0x505a48a2 "jepsen.db$reify__3425@505a48a2"],
 :max-writes-per-key 4,
 :expected-consistency-model :serializable,
 :leave-db-running? false,
 :postgres-password
 "C-EyZ-v5BBFTtPLXu5rI9nPr8_IYz-eeBN3ApLrPtDW1DmVzpdr8qEcOIvIMM7gI",
 :etcd-version "3.4.3",
 :name "stolon append S (S) ",
 :logging-json? false,
 :start-time #clj-time/date-time "2022-02-16T14:59:49.000Z",
 :nemesis-interval 5,
 :net
 #object[jepsen.net$reify__9042 0x60ae950f "jepsen.net$reify__9042@60ae950f"],
 :client {:node nil, :conn nil, :initialized? nil},
 :barrier
 #object[java.util.concurrent.CyclicBarrier 0x702ab027 "java.util.concurrent.CyclicBarrier@702ab027"],
 :pure-generators true,
 :ssh
 {:dummy? true,
  :username "root",
  :password "root",
  :strict-host-key-checking false,
  :private-key-path nil},
 :rate 500,
 :just-postgres false,
 :checker
 #object[jepsen.checker$compose$reify__8566 0x329a27ae "jepsen.checker$compose$reify__8566@329a27ae"],
 :nemesis
 #object[jepsen.nemesis$compose$reify__9222 0x3c3a767 "jepsen.nemesis$compose$reify__9222@3c3a767"],
 :active-histories #<Atom@ee7a538: #{}>,
 :nodes ["appsdb-staging.postgres.pdx.cfdata.org"],
 :test-count 1,
 :generator
 (jepsen.generator.Synchronize{
    :gen jepsen.generator.TimeLimit{
      :limit 60000000000,
      :cutoff nil,
      :gen jepsen.generator.Any{
        :gens [jepsen.generator.OnThreads{
                 :f #{:nemesis},
                 :gen jepsen.generator.Mix{
                   :i 0, :gens []}}
               jepsen.generator.OnThreads{
                 :f #object[clojure.core$complement$fn__5654 0x20e25bf7 "clojure.core$complement$fn__5654@20e25bf7"],
                 :gen jepsen.generator.Stagger{
                   :dt 4000000,
                   :next-time 0,
                   :gen ({:type :invoke,
                          :f :txn,
                          :value
                          [[:append 9 1]
                           [:append 6 1]
                           [:append 9 2]
                           [:r 6 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 9 3] [:append 9 4]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:r 9 nil]
                           [:r 9 nil]
                           [:append 5 1]
                           [:r 8 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:r 8 nil] [:r 9 nil]]}
                         {:type :invoke, :f :txn, :value [[:r 9 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 10 1] [:append 8 1] [:r 10 nil]]}
                         {:type :invoke, :f :txn, :value [[:r 8 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:r 10 nil]
                           [:append 10 2]
                           [:append 7 1]
                           [:r 10 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 8 2]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 10 3]
                           [:append 10 4]
                           [:append 11 1]
                           [:r 8 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 11 2] [:append 11 3]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:r 6 nil] [:r 11 nil] [:append 11 4]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:r 12 nil] [:append 8 3]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 8 4] [:append 12 1] [:r 7 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 4 1]
                           [:append 7 2]
                           [:r 12 nil]
                           [:r 12 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 12 2]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:r 12 nil] [:r 12 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 12 3]
                           [:append 12 4]
                           [:r 12 nil]
                           [:append 14 1]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:r 14 nil] [:r 14 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 13 1] [:r 13 nil] [:r 7 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 7 3]
                           [:r 14 nil]
                           [:r 14 nil]
                           [:append 14 2]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 14 3]
                           [:append 13 2]
                           [:r 14 nil]
                           [:append 14 4]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:r 13 nil] [:append 15 1] [:append 6 2]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 15 2]
                           [:r 13 nil]
                           [:r 13 nil]
                           [:append 13 3]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 15 3] [:r 15 nil] [:append 7 4]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 15 4]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 13 4] [:r 15 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:r 3 nil] [:r 15 nil] [:append 5 2]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:append 6 3]
                           [:r 15 nil]
                           [:r 15 nil]
                           [:r 15 nil]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:r 6 nil] [:append 18 1]]}
                         {:type :invoke,
                          :f :txn,
                          :value [[:append 18 2] [:append 18 3]]}
                         {:type :invoke,
                          :f :txn,
                          :value
                          [[:r 18 nil]
                           [:append 16 1]
                           [:r 18 nil]
                           [:r 18 nil]]}
                         ...)}}]}}}),
 :postgres-port 5432,
 :os
 #object[jepsen.os$reify__2478 0x232899d1 "jepsen.os$reify__2478@232899d1"],
 ...}

INFO [2022-02-16 09:59:49,643] jepsen test runner - jepsen.db Tearing down DB
INFO [2022-02-16 09:59:49,644] jepsen test runner - jepsen.db Setting up DB
INFO [2022-02-16 09:59:49,645] jepsen test runner - jepsen.core Relative time begins now
WARN [2022-02-16 09:59:49,651] main - jepsen.core Test crashed!
clojure.lang.ArityException: Wrong number of args (1) passed to: jepsen.stolon.client/open
	at clojure.lang.AFn.throwArity(AFn.java:429)
	at clojure.lang.AFn.invoke(AFn.java:32)
	at jepsen.stolon.append.Client.open_BANG_(append.clj:126)
	at jepsen.core$run_case_BANG_$fn__9683.invoke(core.clj:219)
	at dom_top.core$real_pmap_helper$build_thread__213$fn__214.invoke(core.clj:146)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:665)
	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973)
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:669)
	at clojure.core$bound_fn_STAR_$fn__5734.doInvoke(core.clj:2003)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Thread.java:833)
WARN [2022-02-16 09:59:49,655] main - jepsen.cli Test crashed
clojure.lang.ArityException: Wrong number of args (1) passed to: jepsen.stolon.client/open
	at clojure.lang.AFn.throwArity(AFn.java:429)
	at clojure.lang.AFn.invoke(AFn.java:32)
	at jepsen.stolon.append.Client.open_BANG_(append.clj:126)
	at jepsen.core$run_case_BANG_$fn__9683.invoke(core.clj:219)
	at dom_top.core$real_pmap_helper$build_thread__213$fn__214.invoke(core.clj:146)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at clojure.core$apply.invokeStatic(core.clj:665)
	at clojure.core$with_bindings_STAR_.invokeStatic(core.clj:1973)
	at clojure.core$with_bindings_STAR_.doInvoke(core.clj:1973)
	at clojure.lang.RestFn.invoke(RestFn.java:425)
	at clojure.lang.AFn.applyToHelper(AFn.java:156)
	at clojure.lang.RestFn.applyTo(RestFn.java:132)
	at clojure.core$apply.invokeStatic(core.clj:669)
	at clojure.core$bound_fn_STAR_$fn__5734.doInvoke(core.clj:2003)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at clojure.lang.AFn.run(AFn.java:22)
	at java.base/java.lang.Thread.run(Thread.java:833)



# Crashed tests

stolon append S (S) 

0 successes
0 unknown
1 crashed
0 failures
```

- This PR fixes this by passing the missing test argument `open` method.