### PR TITLE
Read Postgres Stolon SSL Mode As Command Line Flag

### DIFF
--- a/stolon/src/jepsen/stolon.clj
+++ b/stolon/src/jepsen/stolon.clj
@@ -151,6 +151,12 @@
    [nil "--postgres-password PASS" "What password should we use to connect to postgres?"
     :default "pw"]
 
+   [nil "--postgres-sslmode MODE" "What sslmode should we use to connect to postgres: require, disable?"
+    :default "disable"
+    :parse-fn str
+    :validate [#{"require" "disable"}
+               "Should be one of require, or disable"]]
+
    [nil "--postgres-port NUMBER" "What port should we connect to when talking to postgres?"
     :default 5432
     :parse-fn parse-long]

--- a/stolon/src/jepsen/stolon/client.clj
+++ b/stolon/src/jepsen/stolon/client.clj
@@ -20,12 +20,7 @@
                :port      (:postgres-port     test)
                :user      (:postgres-user     test)
                :password  (:postgres-password test)
-               ; The docs say ssl is a boolean but also it's mere *presence*
-               ; implies using SSL, so... maybe we have to set disable too?
-               :ssl       false
-               ; OK neither of these apparently works, so... let's try in the
-               ; server config.
-               :sslmode   "disable"}
+               :sslmode   (:postgres-sslmode test)}
         spec  (if-let [pt (:prepare-threshold test)]
                 (assoc spec :prepareThreshold pt)
                 spec)


### PR DESCRIPTION
**Description**

- Introduces new flag to configure SSL mode as a command line argument when running Postgres Stolon tests
- Default flag value is `disable`
- Removes unneeded boolean `ssl` field passed into Postgres driver

**Testing**

- This change was tested on a Stolon Postgres cluster which requires SSL
- When the flag value is `--postgres-sslmode disable` or not provided, the following exception is thrown ```WARN [2022-02-21 11:57:10,128] main - jepsen.cli Test crashed
org.postgresql.util.PSQLException: FATAL: login rejected``` (as expected)
- When the flag value is `--postgres-sslmode require` is provided, the test is successful
- When the flag value is neither `require` or `disable` the command is rejected

cc @viggy28