### PR TITLE
WIP: Web: fix datetime parsing so fresh test runs correctly appear

### DIFF
--- a/jepsen/src/jepsen/web.clj
+++ b/jepsen/src/jepsen/web.clj
@@ -70,7 +70,7 @@
 (defn parse-time
   "Parses a time from a string"
   [t]
-  (-> (timef/parse-local basic-date-time t)
+  (-> (timef/parse basic-date-time t)
       time.coerce/to-date-time))
 
 (defn fast-tests
@@ -150,7 +150,7 @@
   (let [r    (:results t)
         time (->> t
                   :start-time
-                  (timef/unparse (timef/formatters :date-hour-minute-second)))]
+                  (timef/unparse-local (timef/formatters :date-hour-minute-second)))]
     [:tr
      [:td [:a {:href (url t "")} (:name t)]]
      [:td [:a {:href (url t "")} time]]


### PR DESCRIPTION
Hi.

I live in UTC+5:00 timezone. I've been learning to use Jepsen, when I encountered bug: my fresh test runs would not appear in Jepsen UI.

![Screenshot_846](https://user-images.githubusercontent.com/7621088/172254975-532ff6a6-b4be-41e9-81fa-f1ec9a83e4a6.png)

I've tried to fix this. The idea is to always operate UTC datetime inside the application and convert to local time only for user output. 
I've built it locally and it works for me:

![Screenshot_845](https://user-images.githubusercontent.com/7621088/172255222-a1a75544-9e99-4d73-abcd-6b72413dfba1.png)

Could you have a look on this PR? I am totally not familiar with clojure and any changes would be welcome.

