### PR TITLE
fix `view source` link in generated API docs (codox source-uri)

### DIFF
--- a/jepsen/project.clj
+++ b/jepsen/project.clj
@@ -47,7 +47,7 @@
                    :logging     :logging
                    :integration :integration}
   :codox {:output-path "doc/"
-          :source-uri "https://github.com/jepsen-io/jepsen/blob/{version}/jepsen/{filepath}#L{line}"
+          :source-uri "https://github.com/jepsen-io/jepsen/blob/v{version}/jepsen/{filepath}#L{line}"
           :metadata {:doc/format :markdown}}
   :profiles {:uberjar {:aot :all}
              :dev {:dependencies [[org.clojure/test.check "1.1.1"]]


### PR DESCRIPTION
`view source` links in generated API docs are missing **v**{version}:

- 404 without the **v**: https://github.com/jepsen-io/jepsen/blob/0.2.7/jepsen/src/jepsen/checker.clj#L737

- work with the **v**:  https://github.com/jepsen-io/jepsen/blob/v0.2.7/jepsen/src/jepsen/checker.clj#L737