### PR TITLE
update tc error message used for net/fast! exception handling

### DIFF
--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -93,7 +93,7 @@
         (try
           (su (exec tc :qdisc :del :dev :eth0 :root))
           (catch RuntimeException e
-            (if (re-find #"RTNETLINK answers: No such file or directory"
+            (if (re-find #"Error: Cannot delete qdisc with handle of zero\."
                          (.getMessage e))
               nil
               (throw e))))))


### PR DESCRIPTION
At some point, the tc error message for an empty qdisc changed (was added?) so it is no longer caught by net/fast!.

This will cause the test to crash when using net/slow!/fast! as a typical Nemesis.
e.g. nemesis/setup! and :final-generator call fast! to insure no faults are in effect, and qdisc is likely empty.

Attempting to use current net/fast!:
```
WARN	[jepsen test runner] jepsen.core: Test crashed!
...
STDERR:
Error: Cannot delete qdisc with handle of zero.
 {:type :jepsen.control/nonzero-exit, :cmd "sudo -k -S -u root bash -c \"cd /; /sbin/tc qdisc del dev eth0 root\"", :out "", :err "Error: Cannot delete qdisc with handle of zero.\n", :exit 2, :host "n3", :action {:cmd "sudo -k -S -u root bash -c \"cd /; /sbin/tc qdisc del dev eth0 root\""}}
```

Manually testing tc behavior on a Jepsen db node (LXC Debian 11):
```
root@n1:~# /sbin/tc qdisc show
qdisc noqueue 0: dev lo root refcnt 2 
qdisc noqueue 0: dev eth0 root refcnt 2 

root@n1:~# /sbin/tc qdisc del dev eth0 root
Error: Cannot delete qdisc with handle of zero.

root@n1:~# /sbin/tc qdisc add dev eth0 root netem delay 50ms 10ms distribution normal
root@n1:~# /sbin/tc qdisc show
qdisc noqueue 0: dev lo root refcnt 2 
qdisc netem 8006: dev eth0 root refcnt 2 limit 1000 delay 50ms  10ms

root@n1:~# /sbin/tc qdisc del dev eth0 root
root@n1:~# /sbin/tc qdisc show
qdisc noqueue 0: dev lo root refcnt 2 
qdisc noqueue 0: dev eth0 root refcnt 2 

root@n1:~# /sbin/tc qdisc del dev eth0 root
Error: Cannot delete qdisc with handle of zero.
```

After catching the new error message:
```
[jepsen worker nemesis] jepsen.util: :nemesis	:info	:start-slow	[:one {:mean 50, :variance 10, :distribution :normal}]
...
[jepsen worker nemesis] jepsen.util: :nemesis	:info	:start-slow	{"n4" ""}
...
[jepsen worker nemesis] jepsen.util: :nemesis	:info	:stop-slow	nil
...
[jepsen worker nemesis] jepsen.util: :nemesis	:info	:stop-slow	{"n1" nil, "n2" nil, "n3" nil, "n4" "", "n5" nil}
```
And using slow!/fast! as a Nemesis:

![image](https://user-images.githubusercontent.com/86082495/181649503-b3e881be-8272-4b74-b84f-a2bcfb1c663f.png)

The current exception message appears to be quite old when doing searches for it, so it was replaced vs added to.

P.S. found this while working towards a combined nemesis package for net/slow!/flaky!/fast!/etc.
Regardless if that proposal is accepted, this PR would allow the current net/fast! to be used and would be carried forward in future changes. 