### PR TITLE
nemesis.combined/packet-(nemesis, package) for packet delay, loss, corruption, duplication, and reordering. Adds packet shaping to Net protocol.

### DIFF
--- a/jepsen/src/jepsen/nemesis/combined.clj
+++ b/jepsen/src/jepsen/nemesis/combined.clj
@@ -246,80 +246,81 @@
                          :stop  #{:stop-partition}
                          :color "#E9DCA0"}}}))
 
-(defn flaky-nemesis
-  "A nemesis to impair, make flaky, the node's network
-  by delaying, losing, corrupting, duplicating, or reordering network packets.
-  Takes a db to work with [[db-nodes]].
+(defn packet-nemesis
+  "A nemesis to disrupt packets, e.g. delay, loss, corruption, etc.
+   Takes a db to work with [[db-nodes]].
    
   This nemesis responds to:
   ```
-  {:f :start-flaky :value [:node-spec                 ; as interpreted by db-nodes
-                           {:fault {},                ; network emulation fault map
-                            :fault {:opt value}...}]} ; specifies faults, option values 
-  {:f :stop-flaky  :value nil}
+  {:f :start-packet :value [:node-spec                 ; as interpreted by db-nodes
+                            {:fault {},                ; packet fault map
+                             :fault {:opt value}...}]} ; specifies faults, option values 
+  {:f :stop-packet  :value nil}
    ```
-  See [[jepsen.net/flaky-network-emulations]]."
+  See [[jepsen.net/packet-faults]]."
   [db]
   (reify
     n/Reflection
     (fs [_this]
-      [:start-flaky  :stop-flaky])
+      [:start-packet  :stop-packet])
 
     n/Nemesis
     (setup! [this {:keys [net] :as test}]
       ;; start from known reliable state
-      (net/reliable! net test)
+      (net/shape! net test nil)
       this)
 
     (invoke! [_this {:keys [net] :as test} {:keys [f value] :as op}]
       (let [result (case f
-                     :start-flaky (let [[node-spec faults] value
-                                        nodes (db-nodes test db node-spec)]
-                                    (net/flaky! net (assoc test :nodes nodes) faults))
-                     :stop-flaky  (net/reliable! net test))]
+                     :start-packet (let [[node-spec faults] value
+                                         nodes (db-nodes test db node-spec)]
+                                     (net/shape! net (assoc test :nodes nodes) faults))
+                     :stop-packet  (net/shape! net test nil))]
         (assoc op :value result)))
 
     (teardown! [_this _test]
       ;; leave network state as is
       )))
 
-(defn flaky-package
-  "A nemesis and generator package for flaky networks.
+(defn packet-package
+  "A nemesis and generator package that disrupts packets,
+   e.g. delay, loss, corruption, etc.
    
    Opts:
    ```clj
-     {:targets   ; A collection of node specs, e.g. [:one, :all]
-      :faults [  ; A collection of fault maps, e.g.:
-       {}                         ; no faults
-       {:delay {}}                ; delay packets by default amount
-       {:corrupt {:percent :33%}} ; corrupt 33% of packets
-       ;; delay packets by default values, plus duplicate 25% of packets
-       {:delay {},
-        :duplicate {:percent :25% :correlation :80%}}]}
+     {:packet
+      {:targets   ; A collection of node specs, e.g. [:one, :all]
+       :faults [  ; A collection of packet fault maps, e.g.:
+        {}                         ; no faults
+        {:delay {}}                ; delay packets by default amount
+        {:corrupt {:percent :33%}} ; corrupt 33% of packets
+        ;; delay packets by default values, plus duplicate 25% of packets
+        {:delay {},
+         :duplicate {:percent :25% :correlation :80%}}]}}
   ```
-  See [[jepsen.net/flaky-network-emulations]].
+  See [[jepsen.net/packet-faults]].
 
   Additional options as for [[nemesis-package]]."
   [opts]
-  (let [needed? ((:faults opts) :flaky)
+  (let [needed? ((:faults opts) :packet)
         db      (:db opts)
-        targets (:targets (:flaky opts) (node-specs db))
-        faults  (:faults (:flaky opts) [{}])
+        targets (:targets (:packet opts) (node-specs db))
+        faults  (:faults  (:packet opts) [{}])
         start   (fn start [_ _]
                   {:type  :info
-                   :f     :start-flaky
+                   :f     :start-packet
                    :value [(rand-nth targets) (rand-nth faults)]})
-        stop    {:type :info
-                 :f :stop-flaky
+        stop    {:type  :info
+                 :f     :stop-packet
                  :value nil}
         gen     (->> (gen/flip-flop start (repeat stop))
                      (gen/stagger (:interval opts default-interval)))]
     {:generator       (when needed? gen)
      :final-generator (when needed? stop)
-     :nemesis         (flaky-nemesis db)
-     :perf            #{{:name  "flaky"
-                         :start #{:start-flaky}
-                         :stop  #{:stop-flaky}
+     :nemesis         (packet-nemesis db)
+     :perf            #{{:name  "packet"
+                         :start #{:start-packet}
+                         :stop  #{:stop-packet}
                          :color "#D1E8A0"}}}))
 
 (defn clock-package
@@ -396,10 +397,10 @@
   "Just like nemesis-package, but returns a collection of packages, rather than
   the combined package, so you can manipulate it further before composition."
   [opts]
-  (let [faults   (set (:faults opts [:partition :flaky :kill :pause :clock]))
+  (let [faults   (set (:faults opts [:partition :packet :kill :pause :clock]))
         opts     (assoc opts :faults faults)]
     [(partition-package opts)
-     (flaky-package opts)
+     (packet-package opts)
      (clock-package opts)
      (db-package opts)]))
 
@@ -431,14 +432,14 @@
     :interval   The interval between operations, in seconds.
     :faults     A collection of enabled faults, e.g. [:partition, :kill, ...]
     :partition  Controls network partitions
-    :flaky      Controls network faults
+    :packet     Controls network packet faults
     :kill       Controls process kills
     :pause      Controls process pauses and restarts
 
   Possible faults:
 
     :partition
-    :flaky
+    :packet
     :kill
     :pause
     :clock
@@ -447,7 +448,7 @@
 
     :targets    A collection of partition specs, e.g. [:majorities-ring, ...]
   
-  Flaky options:
+  Packet options:
     
     :targets    A collection of node specs, e.g. [:one, :all]
     :faults     A collection of fault maps, e.g. [{:delay {}}]


### PR DESCRIPTION
### Add the ability to delay, lose, corrupt, duplicate, and reorder packets by supporting more `tc netem` options in the Net protocol.

Refactor Net/(~~flaky!, !slow!, !fast~~) -> Net(flaky!, reliable!)

  - "the network is flaky!", and its near antonym reliable!, are common descriptions for these faults
  - it's symmetrical, fits generator/flip-flop start/stop for nemesis.combined packages
  - maps to `tc`
    - flaky!    -> `tc ... add netem {opts}`
    - reliable! -> `tc ... del`

Faults, options, and values use `tc-netem` terms.

----

### A fault map describes the desired `tc-netem` (network emulator) state, e.g.:

```clj
{}                         ; no faults
{:delay {}}                ; delay packets by default amount
{:corrupt {:percent :33%}} ; corrupt 33% of packets
;; delay packets by default values, plus duplicate 25% of packets
{:delay {},
 :duplicate {:percent :25% :correlation :80%}}
```

See `jepsen.net/flaky-network-emulations` for all faults and default option values.

----

### To use in your test:
```clj
(nc/nemesis-package
 {...
  :flaky {:targets (:db-targets opts)
          :faults [; typical day
                   {:delay {},
                    :loss  {}}
                   ; ummm, about that firmware update...
                   {:corrupt {:percent :33%}}
                   ; are squirrels partying in the junction box?!?
                   {:delay {},
                    :loss  {},
                    :corrupt   {:percent :15%},
                    :duplicate {:percent :25% :correlation :80%},
                    :reorder   {:percent :30% :correlation :80%}}]}})
```
----

### Reads well in the log:

```clj
:nemesis   :info   :start-flaky    [:minority {:delay {}}]
:nemesis   :info   :start-flaky    {"n1" :flaky, "n5" :flaky}
...
:nemesis   :info   :stop-flaky     nil
:nemesis   :info   :stop-flaky     {"n1" :reliable, "n2" :reliable, "n3" :reliable, "n4" :reliable, "n5" :reliable}
```

### Affects db behavior:

![flaky-nemesis-latency-raw](https://user-images.githubusercontent.com/86082495/182057303-aa9b574d-a8f5-4103-9ca7-1fe8bf9857c0.png)

### Can elicit bugs:

```clj
;; g-set
{:final-reads {:valid? false,
               :missing-count 11,
               :missing (2344
                         2346
                         2348
                         ...)}}
```

### Be observed from cli:

```bash
root@n1:~# ping n2
64 bytes from n2 (192.168.122.102): icmp_seq=1068 ttl=64 time=0.194 ms
# on n2: delay 50ms 10ms 25% distribution normal
64 bytes from n2 (192.168.122.102): icmp_seq=1069 ttl=64 time=49.5 ms

# on n2: corrupt 50% 80%
64 bytes from n2 (192.168.122.102): icmp_seq=858 ttl=64 time=0.228 ms
ping: Warning: time of day goes back (-268435455999786us), taking countermeasures

# on n2: duplicate 33% 80%
64 bytes from n2 (192.168.122.102): icmp_seq=382 ttl=64 time=1.03 ms (DUP!)
```

----

### It's an API change.

I think that's Ok?

- could only find [one modern use](https://github.com/hstreamdb/jepsen.hstream/blob/17bd813cabe8435d89d67ab6cbe361cef3df2c61/src/jepsen/hstream/nemesis.clj#L96) in the wild outside of maelstrom
  -  using Jepsen 0.2.6
  -  would be straightforward to change


I tried using current `Net/(flaky!, slow!, fast!)` and it has issues:

- wrong Exception caught in `fast!`
- API is asymmetrical, not a good fit with typical nemesis combined package start/stop
  - `flaky!` and `slow!` get in each other's way
    -  leading to `tc` Exceptions
    -  `fast!` resets the other's state


So wondering how much of an impact an API change would actually have?

----

`net/(noop, iptables, ipfilter)` have been updated for the new Net protocol.

If the PR is accepted, `maelstrom.net/net` can also be updated.

Developed and tested with LXC on Debian 11.

Please let me know if you want any renaming, code, doc, or any other changes.
