### PR TITLE
packet-nemesis: use tc filters to only shape to/from traffic of `:targets` db nodes 

### DIFF
--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -9,7 +9,7 @@
             [jepsen.control :refer :all]
             [jepsen.control.net :as control.net]
             [jepsen.net.proto :as p]
-            [slingshot.slingshot :refer [throw+]]))
+            [slingshot.slingshot :refer [throw+ try+]]))
 
 ; TODO: move this into jepsen.net.proto
 (defprotocol Net
@@ -24,7 +24,9 @@
                                 ```")
   (flaky! [net test]           "Introduces randomized packet loss")
   (fast!  [net test]           "Removes packet loss and delays.")
-  (shape! [net test behaviors] "Shapes network behavior, i.e. packet delay, loss, corruption, duplication, and reordering."))
+  (shape! [net test nodes behavior] "Shapes network behavior,
+                                     i.e. packet delay, loss, corruption, duplication, reordering, and rate
+                                     for the given nodes."))
 
 ; Top-level API functions
 (defn drop-all!
@@ -46,21 +48,42 @@
 
 (def tc "/sbin/tc")
 
+(defn net-dev
+  "Returns the network interface of the current host."
+  []
+  (let [choices (su (exec :ls "/sys/class/net/"))
+        iface (->> choices
+                   (str/split-lines)
+                   (remove (fn [iface] (re-find #"^lo" iface)))
+                   first)]
+    (assert iface
+            (str "Couldn't determine network interface!\n" choices))
+    iface))
+
+(defn qdisc-del
+  "Deletes root qdisc for given dev on current node."
+  [dev]
+  (try+
+   (su (exec tc :qdisc :del :dev dev :root))
+   (catch [:exit 2] {}
+     ; no qdisc to del
+     nil)))
+
 (def all-packet-behaviors
   "All of the available network packet behaviors, and their default option values.
 
    Caveats:
    
-     - behaviors are applied at the node network level, i.e. all egress regardless of destination, type, etc.
-     - `:delay` - Use `:normal` distribution of delays for more typical network behavior. 
-     - `:loss`  - When used locally (not on a bridge or router), the loss is reported to the upper level protocols.
+     - behaviors are applied to a node's network interface and effect all db to db node traffic
+     - `:delay` - Use `:normal` distribution of delays for more typical network behavior
+     - `:loss`  - When used locally (not on a bridge or router), the loss is reported to the upper level protocols
                   This may cause TCP to resend and behave as if there was no loss.
    
    See [tc-netem(8)](https://manpages.debian.org/bullseye/iproute2/tc-netem.8)."
   {:delay     {:time         :50ms
                :jitter       :10ms
                :correlation  :25%
-               :distribution [:distribution :normal]}  ; uniform | normal | pareto |  paretonormal
+               :distribution :normal}
    :loss      {:percent      :20%
                :correlation  :75%}
    :corrupt   {:percent      :20%
@@ -68,53 +91,75 @@
    :duplicate {:percent      :20%
                :correlation  :75%}
    :reorder   {:percent      :20%
-               :correlation  :75%}})
+               :correlation  :75%}
+   :rate      {:rate         :1mbit}})
 
-(defn- delete-netem!
-  "Deletes a network emulation, assumed to have fault'y behavior, returning nodes to reliability."
-  [_net test]
-  (with-test-nodes test
-    ;; may already be reliable, i.e. no queuing discipline
-    (try
-      (su (exec tc :qdisc :del :dev :eth0 :root))
-      :reliable
-      (catch RuntimeException e
-        (if (re-find #"Error: Cannot delete qdisc with handle of zero\."
-                     (.getMessage e))
-          :reliable
-          (throw e))))))
+(defn- behaviors->netem
+  "Given a map of behaviors, returns a sequence of netem options."
+  [behaviors]
+  (->>
+   ; :reorder requires :delay
+   (if (and (:reorder behaviors)
+            (not (:delay behaviors)))
+     (assoc behaviors :delay (:delay all-packet-behaviors))
+     behaviors)
+   ; fill in all unspecified opts with default values
+   (reduce (fn [acc [behavior opts]]
+             (assoc acc behavior (merge (behavior all-packet-behaviors) opts)))
+           {})
+   ; build a tc cmd line combining all behaviors
+   (reduce (fn [args [behavior {:keys [time jitter percent correlation distribution rate] :as _opts}]]
+             (case behavior
+               :delay
+               (concat args [:delay time jitter correlation :distribution distribution])
+               (:loss :corrupt :duplicate :reorder)
+               (concat args [behavior percent correlation])
+               :rate
+               (concat args [:rate rate])))
+           [])))
 
-(defn- set-netem!
-  "Sets a network emulation with given `behaviors` to disrupt packets.
-   Shared convenience call for iptables/ipfilter."
-  [net test behaviors]
-  (if (seq behaviors)
-    (do
-      (assert (if (:reorder behaviors)
-                (:delay behaviors)
-                true)
-              "Cannot reorder packets without a delay.")
-      ;; reset node networks to reliable before introducing new queuing discipline
-      (delete-netem! net test)
-      (let [tc-opts (->> behaviors
-                         ;; fill in all unspecified opts with default values
-                         (reduce (fn [acc [behavior opts]]
-                                   (assoc acc behavior (merge (behavior all-packet-behaviors) opts)))
-                                 {})
-                         ;; build a tc cmd line combining all behaviors
-                         (reduce (fn [args [behavior {:keys [time jitter percent correlation distribution] :as _opts}]]
-                                   (case behavior
-                                     :delay
-                                     (concat args [:delay time jitter correlation distribution])
-                                     (:loss :corrupt :duplicate :reorder)
-                                     (concat args [behavior percent correlation])))
-                                 [:qdisc :add :dev :eth0 :root :netem]))]
-        (with-test-nodes test
-          (do
-            (su (exec tc tc-opts))
-            :shaped))))
-    ;; no queuing discipline desired, delete any existing shaping
-    (delete-netem! net test)))
+(defn- net-shape!
+  "Shared convenience call for iptables/ipfilter.
+   Shape the network with tc qdisc, netem, and filter(s) so target nodes have given behavior."
+  [_net {:keys [nodes] :as _test} targets behavior]
+  (let [results (on-many nodes
+                         (let [nodes   (set nodes)
+                               targets (set targets)
+                               targets (if (contains? targets *host*)
+                                         (disj nodes *host*)
+                                         targets)
+                               dev     (net-dev)]
+                           ; start with no qdisc
+                           (qdisc-del dev)
+                           (if (and (seq targets)
+                                    (seq behavior))
+                             ; node will need a prio qdisc, netem qdisc, and a filter per target
+                             (do
+                               (su
+                                ; root prio qdisc, bands 1:1-3 are system default prio
+                                (exec tc
+                                      :qdisc :add :dev dev
+                                      :root :handle "1:"
+                                      :prio :bands 4 :priomap 1 2 2 2 1 2 0 0 1 1 1 1 1 1 1 1)
+                                ; band 1:4 is a netem qdisc for the behavior
+                                (exec tc
+                                      :qdisc :add :dev dev
+                                      :parent "1:4" :handle "40:"
+                                      :netem (behaviors->netem behavior))
+                                ; filter dst ip's to netem qdisc with behavior
+                                (doseq [target targets]
+                                  (exec tc
+                                        :filter :add :dev dev
+                                        :parent "1:0"
+                                        :protocol :ip :prio :3 :u32 :match :ip :dst (control.net/ip target)
+                                        :flowid "1:4")))
+                               targets)
+                             ; no targets and/or behavior, so no qdisc/netem/filters
+                             nil)))]
+    ; return a more readable value
+    (if (and (seq targets) (seq behavior))
+      [:shaped   results :netem (vec (behaviors->netem behavior))]
+      [:reliable results])))
 
 (def noop
   "Does nothing."
@@ -125,7 +170,7 @@
     (slow!  [net test opts])
     (flaky! [net test])
     (fast!  [net test])
-    (shape! [net test behaviors])))
+    (shape! [net test nodes behavior])))
 
 (def iptables
   "Default iptables (assumes we control everything)."
@@ -170,8 +215,8 @@
               nil
               (throw e))))))
 
-    (shape! [net test behaviors]
-      (set-netem! net test behaviors))
+    (shape! [net test nodes behavior]
+      (net-shape! net test nodes behavior))
 
     p/PartitionAll
     (drop-all! [net test grudge]
@@ -219,5 +264,5 @@
       (with-test-nodes test
         (su (exec :tc :qdisc :del :dev :eth0 :root))))
 
-    (shape! [net test behaviors]
-      (set-netem! net test behaviors))))
+    (shape! [net test nodes behavior]
+      (net-shape! net test nodes behavior))))


### PR DESCRIPTION
The original packet-nemesis is a bit simplistic.
It adds a netem qdisc to `:targets` db nodes that affect all outbound traffic.
This includes the control node and ignores any effects on inbound traffic from other nodes.

In the original PR merge discussion
you provided a [sample gist](https://gist.github.com/aphyr/6d40e0febf25d12653b0abb868b6bf9e) showing how to have a standard priority queue for good traffic,
and use filters to a netem queue for bad traffic. 

Switching to those techniques in this PR, the packet-nemesis will effect the inbound traffic to, and the outbound traffic from `:targets` db nodes only.

Control node traffic remains reliable.

Affecting both inbound traffic to and outbound traffic from `:targets` seems more natural.
Can use `:all` for whole network.
More aligned with how other packages work, these `:targets` will be impacted, have this relationship with the other nodes, etc.

The log messages are more like other packages:
```clj
:start-packet   [:one {:delay {}, :rate {:rate :1mbit}}]
:start-packet   [:shaped {"n1" #{"n5"}, "n2" #{"n5"}, "n3" #{"n5"}, "n4" #{"n5"}, "n5" #{"n2" "n1" "n4" "n3"}} :netem [:delay :50ms :10ms :25% :distribution :normal :rate :1mbit]]
...
:stop-packet    nil
:stop-packet    [:reliable {"n1" nil, "n2" nil, "n3" nil, "n4" nil, "n5" nil}]
```

To use random property style with packet-package:
```clj
{:packet {:targets (:db-targets opts)
          :behaviors (for [_ (range 10)]
                       (->> net/all-packet-behaviors
                            (random-sample (/ (+ 1 (rand-int 3))
                                              (count net/all-packet-behaviors)))
                            (into {})))}}
```

More comprehensive, test-all style with packet-nemesis:
```clj
; Every combination of network latency and rate limit
; effecting the entire network:
(->> (for [rate    (:net-rates test)
           latency (:net-latencies test)]
       ...
       {:type  :info,
        :f     :start-packet,
        :value [:all {:delay {:time latency}
                      :rate  {:rate rate}}]}))
```

Limping hardware/node:
```clj
; "n1" progressively getting worse...
(gen/flip-flop (map (fn [delay-time corrupt]
                      {:type  :info
                       :f     :start-packet
                       :value [["n1"]
                               {:delay   {:time    (str delay-time "ms")}
                                :corrupt {:percent (str corrupt "%")}}]})
                    (cycle (range 100 1001 100))
                    (cycle (range 10 101 10)))
                (repeat {:type  :info
                         :f     :stop-packet
                         :value nil}))
```

Keep pushing a majority further and further apart until consensus isn't practical/possible.
How far apart is that how does cluster fail?:
```clj
(map (fn [delay]
       {:type :info,
        :f    :start-packet,
        :value [:majority {:delay {:time delay}}]})
     (range))
```

At minimum, I would like to fix the issue of control node traffic being impacted.
I also think using filters for both to/from `:targets` nodes is more package'y and a slightly better fit for common scenarios.

Is this Ok?
(I think it's closer to what I should have originally submitted a couple of weeks ago.)

Or any desired changes?

Thanks!