### PR TITLE
add nemesis.combined/file-corruption-package, enhance nemesis/(bitflip, truncate-file)

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -30,10 +30,13 @@
             opts))))
 
 (defn file?
+  "Is `filename` a regular file that exists?"
   [filename]
-  (throw (RuntimeException. "Use exists? instead; file? will be used to tell if
-                            something is a file, as opposed to a directory or
-                            link.")))
+  (try+
+   (exec :test :-f filename)
+   true
+   (catch [:exit 1] _
+     false)))
 
 (defn exists?
   "Is a path present?"

--- a/jepsen/src/jepsen/nemesis/combined.clj
+++ b/jepsen/src/jepsen/nemesis/combined.clj
@@ -529,6 +529,6 @@
   File corruption options:
     
     :targets     A collection of node specs, e.g. [:one, :all]
-    :corruptions A collection of file corruptions, e.g. [{:bitflip \"/data/dir\" :probability 1e-3}]"
+    :corruptions A collection of file corruptions, e.g. [{:type :bitflip, :file \"/path/to/file\" :probability 1e-3}]"
   [opts]
   (compose-packages (nemesis-packages opts)))


### PR DESCRIPTION
This PR proposes to add file corruption to `nemesis/combined`,
and in doing so enhance `bitflip` and `truncate-file` nemeses.

----

Hopefully the docs are a clear explanation:

### file-corruption-package

Opts:

```clj
{:file-corruption
 {:targets     [...] ; A collection of node specs, e.g. [:one, [\"n1\", \"n2\"], :all]
  :corruptions [     ; A collection of file corruptions, e.g.:
   {:bitflip "/path/to/file"
    :probability 1e-3},
   {:bitflip "/path/to/dir"
    :probability [1e-3 1e-4 1e-5]},
   {:truncate "/path/to/file/or/dir"
    :drop (range 1 1025)}]}}
```
If a directory is given to `:bitflip` or `:truncate`,
a new random file is selected from that directory on each target node for each operation.

If `:probability` or `:drop` is a collection, a new `rand-nth` value is chosen for each operation.

----

In the logs:
```clj
:nemesis :info :bitflip {"n1" {:file "/root/antidote/data_riak_core", :probability 1.0E-4}}
:nemesis :info :bitflip {"n1" {:file "/root/antidote/data_riak_core/riak_core_ring.default.20220831033635", :probability 1.0E-4}}
...
:nemesis :info :truncate {"n1" {:file "/root/antidote/data_antidote", :drop 269}, "n2" {:file "/root/antidote/data_antidote", :drop 269}}
:nemesis :info :truncate {"n1" {:file "/root/antidote/data_antidote/1027618338748291114361965898003636498195577569280--1027618338748291114361965898003636498195577569280.LOG", :drop 269}, "n2" {:file "/root/antidote/data_antidote/365375409332725729550921208179070754913983135744--365375409332725729550921208179070754913983135744.LOG", :drop 269}}
```
----

The generator functions need to be lightweight.

The existing `bitflip` and `truncate-file` take a specific `:file` to operate on. This forces any random selection of files into the generator.
Doing operations like `file?` and `ls-full` from a generator are way too heavyweight side-effects. Jepsen gets *quite* weird when generators take a lot of time and interact with other parts of the system.

Enhancing `:file` to be either a file or a directory to select a random file from allows the generator to stay lite and the nemesis to do the needed work.
It's also backwards compatible.

----

### bitflip

A nemesis which introduces random bitflips in files. Takes operations like:
```clj
{:f     :bitflip
 :value {"some-node" {:file        "/path/to/file or /path/to/dir"
                      :probability 1e-3}}}
```
This flips 1 x 10^-3 of the bits in `/path/to/file`, or a random file in `/path/to/dir`, on "some-node".

----

### truncate-file

A nemesis which responds to
  ```clj
  {:f     :truncate
   :value {"some-node" {:file "/path/to/file or /path/to/dir"
                        :drop 64}}}
  ```
  where the value is a map of nodes to `{:file, :drop}` maps, on those nodes,
  drops the last `:drop` bytes from the given file, or a random file from the given directory.

----

One other misc change was to (re)enable `cu/file?`.
It was deprecated 6 years ago for `cu/exists?`.
If that's not Ok it can be moved inline.

----

My initial usage:

```clj
:file-corruption {:targets     [["n1"]]
                  :corruptions [{:bitflip db/node-antidote-data-dir
                                 :probability [1e-2 1e-3 1e-4]}
                                {:bitflip db/node-antidote-riak-dir
                                 :probability [1e-2 1e-3 1e-4]}]}
```

With the random generators finding a tender target:

```clj
:nemesis :info :bitflip {"n1" {:file "/root/antidote/data_antidote", :probability 1.0E-4}}
:nemesis :info :bitflip {"n1" {:file "/root/antidote/data_antidote/a_stable_meta_data_table", :probability 1.0E-4}}
```

To replicate what the etcd test does for file corruption:

```clj
:file-corruption {:targets     [["n1" "n2"]] ; or a minority function
                  :corruptions [{:bitflip "/member/wal"
                                 :probability [1e-3 1e-4 1e-5]}
                                {:bitflip "/member/snap"
                                 :probability [1e-3 1e-4 1e-5]}
                                {:truncate "/member/wal"
                                 :drop (range 1 1025)}]}
```

I was pretty sure that a `file-corruption-package` would be welcome so went ahead with a proposed implementation that tried to fit into the existing framework and usage. Am open to redoing anything that doesn't fit.

Is this too much? A good idea? Should be done differently?

Thanks!
