### PR TITLE
docker: Update debian & jdk versions

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 MAINTAINER jake@apache.org
 
 ENV LEIN_ROOT true
@@ -7,7 +7,7 @@ ENV LEIN_ROOT true
 # Jepsen dependencies
 #
 RUN apt-get -y -q update && \
-    apt-get install -qy openjdk-11-jdk-headless \
+    apt-get install -qy openjdk-17-jdk-headless \
     libjna-java \
     vim \
     emacs \


### PR DESCRIPTION
Debian buster will reach its EOL soon (source: https://wiki.debian.org/DebianReleases), bumping the dependency to the last release