### PR TITLE
Use `strict-host-key-checking` argument in SSHJ and SCP

### DIFF
--- a/jepsen/src/jepsen/control/scp.clj
+++ b/jepsen/src/jepsen/control/scp.clj
@@ -64,6 +64,8 @@
          "-P" (str (:port conn-spec))
          (concat (when-let [k (:private-key-path conn-spec)]
                    ["-i" k])
+                 (if-not (:strict-host-key-checking conn-spec)
+                   ["-o StrictHostKeyChecking=no"])
                  sources
                  [dest]))
   nil)

--- a/jepsen/src/jepsen/control/sshj.clj
+++ b/jepsen/src/jepsen/control/sshj.clj
@@ -112,10 +112,14 @@
   (connect [this conn-spec]
     (if (:dummy conn-spec)
       (assoc this :conn-spec conn-spec)
-      (try+ (let [c (doto (SSHClient.)
-                      (.loadKnownHosts)
-                      (.connect (:host conn-spec) (:port conn-spec))
-                      (auth! conn-spec))]
+      (try+ (let [c (as-> (SSHClient.) client
+                      (do
+                        (if (:strict-host-key-checking conn-spec)
+                          (.loadKnownHosts client)
+                          (.addHostKeyVerifier client (PromiscuousVerifier.)))
+                        (.connect client (:host conn-spec) (:port conn-spec))
+                        (auth! client conn-spec)
+                        client))]
               (assoc this
                      :conn-spec conn-spec
                      :client c


### PR DESCRIPTION
`strict-host-key-checking`argument is ignored in SSHJ as far as I see.
It should be used correctly now both in SSHJ and SCP.