### PR TITLE
PromiscuousVerifier dependency missed

### DIFF
--- a/jepsen/src/jepsen/control/sshj.clj
+++ b/jepsen/src/jepsen/control/sshj.clj
@@ -18,6 +18,7 @@
            (net.schmizz.sshj.connection ConnectionException)
            (net.schmizz.sshj.connection.channel OpenFailException)
            (net.schmizz.sshj.connection.channel.direct Session)
+           (net.schmizz.sshj.transport.verification PromiscuousVerifier)
            (net.schmizz.sshj.userauth UserAuthException)
            (net.schmizz.sshj.userauth.method AuthMethod)
            (net.schmizz.sshj.xfer FileSystemFile)


### PR DESCRIPTION
While trying to execute `lein install` got 
```
#0 20.56 Compiling jepsen.cli
#0 30.49 Syntax error compiling new at (jepsen/control/sshj.clj:119:55).
#0 30.87 Syntax error (IllegalArgumentException) compiling new at (jepsen/control/sshj.clj:119:55).
#0 30.87 Unable to resolve classname: PromiscuousVerifier
```

Added the missed `PromiscuousVerifier` dependency.