### PR TITLE
jepsen.net/net-dev: (more) correctly identify the network interface by using ip vs /sys/class/net

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -124,7 +124,7 @@
                 (catch [:type :jepsen.control/nonzero-exit, :exit 4] e
                   (if (pos? tries)
                     ::retry
-                    (throw e))))]
+                    (throw+ e))))]
       (if (= ::retry res)
         (recur (dec tries))
         res))))

--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -51,11 +51,12 @@
 (defn net-dev
   "Returns the network interface of the current host."
   []
-  (let [choices (su (exec :ls "/sys/class/net/"))
+  (let [choices (su (exec :ip :-o :link :show))
         iface (->> choices
                    (str/split-lines)
-                   (remove (fn [iface] (re-find #"^lo" iface)))
-                   first)]
+                   (map (fn [ln] (let [[_match iface] (re-find #"\d+: ([^:@]+).+" ln)] iface)))
+                   (remove #(= "lo" %))
+                   (first))]
     (assert iface
             (str "Couldn't determine network interface!\n" choices))
     iface))


### PR DESCRIPTION
Hi,

`jepsen.net/net-dev` currently identifies the network interface by looking in `/sys/class/net`.
Previous to that it was hard coded to `eth0`.

This works well with LXC containers and/or VMs.

In other container environments, depending on their config and how they're started, looking in  `/sys/class/net` can be misleading.
It can show `docker0`, `veth-this`, `veth-that`, etc., in addition to the actual container interface.

`ip` is network namespace aware and will only show interfaces that can actually be used in the container namespace.

This has been tested with Debian/LXC and Ubuntu in Docker with namespaces.

----

And then a misc found during debugging:

`jepsen.control.util/wget-helper!` needs to `throw+` on error as the exec result is a map, not an Exception.

This allows a wget failure to present as an Exception with the result map for debugging, vs a class cast Exception.

----

And if this PR is accepted, could it also be followed with a `0.3.2-SNAPSHOT` to clojars?

Thanks!