### PR TITLE
Fix clock changes in latest Jepsen

### DIFF
--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -10,12 +10,14 @@ x-node:
     - /run:size=100M
     - /run/lock:size=100M
   volumes:
+    - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
+    - "/etc/timezone:/etc/timezone:ro"
+    - "/etc/localtime:/etc/localtime:ro"
     - "jepsen-shared:/var/jepsen/shared"
   networks:
     - jepsen
-  privileged: true
   cap_add:
-    - ALL
+    - NET_ADMIN
   ports:
     - ${JEPSEN_PORT:-22}
 
@@ -44,5 +46,7 @@ services:
     networks:
       - jepsen
     volumes:
+      - "/etc/timezone:/etc/timezone:ro"
+      - "/etc/localtime:/etc/localtime:ro"
       - "jepsen-shared:/var/jepsen/shared"
 %%DBS%%


### PR DESCRIPTION
This partially reverts a previous commit, which added `privileged: true` and `capabilities: ALL` to Docker test nodes. It also adds mounts which should ensure the containers come up with the same local time as the host.

Closes #568