### PR TITLE
docker compose has fixed its cgroupns host configuration bug(s), improved support for OS/systemd containers

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ generate computers is *cloud native*.
 
 ## Quickstart
 
-Assuming you have docker-compose set up already, run:
+Assuming you have `docker compose` set up already, run:
 
 ```
 bin/up

--- a/docker/bin/up
+++ b/docker/bin/up
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# "To provide additional docker-compose args, set the COMPOSE var. Ex:
+# "To provide additional docker compose args, set the COMPOSE var. Ex:
 # COMPOSE="-f FILE_PATH_HERE"
 
 set -o errexit
@@ -57,7 +57,7 @@ do
                 export JEPSEN_ROOT
                 INFO "JEPSEN_ROOT is not set, defaulting to: $JEPSEN_ROOT"
             fi
-            INFO "Running docker-compose with dev config"
+            INFO "Running docker compose with dev config"
             DEV="-f docker-compose.dev.yml"
             shift # past argument
             ;;
@@ -67,7 +67,7 @@ do
             shift # past value
             ;;
         -d|--daemon)
-            INFO "Running docker-compose as daemon"
+            INFO "Running docker compose as daemon"
             RUN_AS_DAEMON=1
             shift # past argument
             ;;
@@ -91,10 +91,10 @@ if [ "${HELP}" -eq 1 ]; then
     echo "Usage: $0 [OPTION]"
     echo "  --help                                                Display this message"
     echo "  --init-only                                           Initializes ssh-keys, but does not call docker-compose"
-    echo "  --daemon                                              Runs docker-compose in the background"
+    echo "  --daemon                                              Runs docker compose in the background"
     echo "  --dev                                                 Mounts dir at host's JEPSEN_ROOT to /jepsen on jepsen-control container, syncing files for development"
     echo "  --compose PATH                                        Path to an additional docker-compose yml config."
-    echo "To provide multiple additional docker-compose args, set the COMPOSE var directly, with the -f flag. Ex: COMPOSE=\"-f FILE_PATH_HERE -f ANOTHER_PATH\" ./up.sh --dev"
+    echo "To provide multiple additional docker compose args, set the COMPOSE var directly, with the -f flag. Ex: COMPOSE=\"-f FILE_PATH_HERE -f ANOTHER_PATH\" ./up.sh --dev"
     exit 0
 fi
 
@@ -157,27 +157,24 @@ fi
 exists docker ||
     { ERROR "Please install docker (https://docs.docker.com/engine/installation/)";
       exit 1; }
-exists docker-compose ||
-    { ERROR "Please install docker-compose (https://docs.docker.com/compose/install/)";
-      exit 1; }
 
-INFO "Running \`docker-compose build\`"
+INFO "Running \`docker compose build\`"
 # shellcheck disable=SC2086
-docker-compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} build
+docker compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} build
 
 # We need a fresh share volume each time we start, so we have a correct set of
 # DB hosts. Why does Docker make sharing state SO hard
 docker run --rm -v jepsen_jepsen-shared:/data/ debian:buster rm /data/nodes || true
 
-INFO "Running \`docker-compose up\`"
+INFO "Running \`docker compose up\`"
 if [ "${RUN_AS_DAEMON}" -eq 1 ]; then
     # shellcheck disable=SC2086
-    docker-compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} up -d
+    docker compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} up -d
     INFO "All containers started! Run \`docker ps\` to view, and \`bin/console\` to get started."
 else
     INFO "Please run \`bin/console\` in another terminal to proceed"
     # shellcheck disable=SC2086
-    docker-compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} up
+    docker compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} up
 fi
 
 popd

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,5 +1,7 @@
 FROM debian:bullseye
-MAINTAINER jake@apache.org
+
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
 
 ENV LEIN_ROOT true
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   control:
     volumes:

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,11 +1,9 @@
-# See https://github.com/jgoerzen/docker-debian-base
+# See https://salsa.debian.org/jgoerzen/docker-debian-base
 # See https://hub.docker.com/r/jgoerzen/debian-base-standard
-FROM jgoerzen/debian-base-standard:buster
+FROM jgoerzen/debian-base-standard:bullseye
 
-# I think this is a bug--debian-base-setup crashes because policy-rc.d isn't
-# present in this image, and if you create it, exim crashes... do we actually NEED this? Maybe not...
-#RUN mkdir /usr/sbin/policy-rc.d
-#RUN run-parts --exit-on-error --verbose /usr/local/debian-base-setup
+ENV container=docker
+STOPSIGNAL SIGRTMIN+3
 
 # Basic system stuff
 RUN apt-get update

--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 x-node:
   &default-node
   build: ./node
@@ -9,11 +8,12 @@ x-node:
   tmpfs:
     - /run:size=100M
     - /run/lock:size=100M
+  cgroup: host
   volumes:
+    - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     - "jepsen-shared:/var/jepsen/shared"
   networks:
     - jepsen
-  privileged: true
   cap_add:
     - ALL
   ports:
@@ -37,7 +37,6 @@ services:
 %%DEPS%%
     build: ./control
     env_file: ./secret/control.env
-    privileged: true
     ports:
       - "22"
       - "8080"


### PR DESCRIPTION
I know, docker, but this time a bit of better news.

Docker released new versions earlier this week with improved support for OS/systemd containers like Jepsen uses, e.g. `jgoerzen/debian-base-standard`.

Docker compose not configuring cgroups correctly, Debian/systemd moving to v2, others moving at different paces, explains many of the recent config workarounds.

It is now possible to configure docker as recommended by [debian-base-standard](https://salsa.debian.org/jgoerzen/docker-debian-base#container-invocation-systemd-containers-busterbullseyesid) and [systemd](https://systemd.io/CONTAINER_INTERFACE/
):
```yaml
cgroup: host
volumes:
  - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
# no privileged: true

# leave CAP as is to be conservative, per systemd:
#   "Do not drop CAP_SYS_ADMIN from the container"
cap_add:
  - ALL
```

With this configuration on Debian/bullseye, Jepsen works with Docker:

![image](https://user-images.githubusercontent.com/86082495/230506705-a8f0f6fa-ce4a-49c1-877a-232dbfa76949.png)

As Docker updated all of the architectures, this may be an end to (some of) the flip-flopping. I do think the config in `main` should reflect Debian stable.

----

Changes:

Node `Dockerfile` updated to `bullseye`:
```dockerfile
FROM jgoerzen/debian-base-standard:bullseye
```

`docker-compose` as an independent entity is going away and will be a plugin, `docker compose`
> [From the end of June 2023 Compose V1 won’t be supported anymore ...](https://docs.docker.com/compose/)
- change `docker-compose` -> `docker compose` 


Misc yaml linting:
- well behaved with systemd
  ```dockerfile
  ENV container=docker
  STOPSIGNAL SIGRTMIN+3
  ```
- update comments
- remove
  - `version:`
  - `MAINTAINER`
