### PR TITLE
tune docker compose, Dockerfiles

### DIFF
--- a/docker/bin/up
+++ b/docker/bin/up
@@ -162,10 +162,6 @@ INFO "Running \`docker compose build\`"
 # shellcheck disable=SC2086
 docker compose --compatibility -p jepsen -f docker-compose.yml ${COMPOSE} ${DEV} build
 
-# We need a fresh share volume each time we start, so we have a correct set of
-# DB hosts. Why does Docker make sharing state SO hard
-docker run --rm -v jepsen_jepsen-shared:/data/ debian:buster rm /data/nodes || true
-
 INFO "Running \`docker compose up\`"
 if [ "${RUN_AS_DAEMON}" -eq 1 ]; then
     # shellcheck disable=SC2086

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM jgoerzen/debian-base-standard:bullseye
 
 ENV container=docker
 STOPSIGNAL SIGRTMIN+3
@@ -8,20 +8,9 @@ ENV LEIN_ROOT true
 #
 # Jepsen dependencies
 #
-RUN apt-get -y -q update && \
-    apt-get install -qy openjdk-17-jdk-headless \
-    libjna-java \
-    vim \
-    emacs \
-    git \
-    htop \
-    screen \
-    pssh \
-    curl \
-    wget \
-    gnuplot \
-    graphviz \
-    dos2unix
+RUN apt-get -qy update && \
+    apt-get -qy install \
+        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-17-jdk-headless pssh screen vim wget
 
 RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     mv lein /usr/bin && \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -6,15 +6,14 @@ ENV container=docker
 STOPSIGNAL SIGRTMIN+3
 
 # Basic system stuff
-RUN apt-get update
-RUN apt-get install -y apt-transport-https
+RUN apt-get -qy update && \
+    apt-get -qy install \
+        apt-transport-https
 
 # Install packages
 RUN apt-get -qy update && \
     apt-get -qy install \
-        dos2unix \
-        openssh-server \
-        pwgen
+        dos2unix openssh-server pwgen
 
 # When run, boot-debian-base will call this script, which does final
 # per-db-node setup stuff.
@@ -28,7 +27,9 @@ RUN sed -i "s/#PermitRootLogin prohibit-password/PermitRootLogin yes/g" /etc/ssh
 ENV DEBBASE_SSH enabled
 
 # Install Jepsen deps
-RUN apt-get install -qy build-essential bzip2 curl dnsutils faketime iproute2 iptables iputils-ping libzip4 logrotate man man-db net-tools ntpdate psmisc python rsyslog sudo tar unzip vim wget ca-certificates
+RUN apt-get -qy update && \
+    apt-get -qy install \
+        build-essential bzip2 ca-certificates curl dirmngr dnsutils faketime iproute2 iptables iputils-ping libzip4 logrotate man man-db netcat net-tools ntpdate psmisc python rsyslog sudo tar tcpdump unzip vim wget
 
 EXPOSE 22
 CMD ["/usr/local/bin/boot-debian-base"]

--- a/docker/template/depends.yml
+++ b/docker/template/depends.yml
@@ -1,1 +1,2 @@
-      - n%%N%%
+      n%%N%%:
+        condition: service_healthy

--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -18,6 +18,16 @@ x-node:
     - ALL
   ports:
     - ${JEPSEN_PORT:-22}
+  stop_signal: SIGRTMIN+3
+  healthcheck:
+    test: [ 'CMD-SHELL', 'systemctl status sshd | grep "Active: active (running)"' ]
+    interval: 1s
+    timeout: 1s
+    retries: 3
+    start_period: 3s
+  depends_on: 
+    setup:
+      condition: service_completed_successfully
 
 volumes:
   jepsen-shared:
@@ -30,6 +40,13 @@ networks:
   jepsen:
 
 services:
+  setup:
+    image: jgoerzen/debian-base-standard:bullseye
+    container_name: jepsen-setup
+    hostname: setup
+    volumes:
+      - "jepsen-shared:/var/jepsen/shared"
+    entrypoint: [ 'rm', '-rf', '/var/jepsen/shared/nodes' ] 
   control:
     container_name: jepsen-control
     hostname: control
@@ -44,4 +61,5 @@ services:
       - jepsen
     volumes:
       - "jepsen-shared:/var/jepsen/shared"
+    stop_signal: SIGRTMIN+3
 %%DBS%%


### PR DESCRIPTION
In docker compose, the control node `depends_on: n1...` so the db nodes are available for the ssh-keyscan.

I've noticed that docker compose will sometimes race the startup of the control node so the ssh-keyscan fails for some node(s). docker compose documentation:
```
Compose implementations MUST guarantee dependency services have been started before starting a dependent service.
Compose implementations MAY wait for dependency services to be “ready” before starting a dependent service.
```

So a simple `healthcheck:`, is sshd active and running?, was added to the docker-compose.yml for the db nodes.

----

docker compose was warning that it wants `jepsen-shared` to be a compose volume vs an `external:` volume due to:

```bash
# We need a fresh share volume each time we start, so we have a correct set of
# DB hosts. Why does Docker make sharing state SO hard
docker run --rm -v jepsen_jepsen-shared:/data/ debian:buster rm /data/nodes || true
```

So the setup has been moved to compose:
```yaml
setup:
    volumes:
      - "jepsen-shared:/var/jepsen/shared"
    entrypoint: [ 'rm', '-rf', '/var/jepsen/shared/nodes' ]  
```

----

Initial commit didn't include `stop_signal: SIGRTMIN+3` in docker-compose.yml

----

And in some possibly OCD'ish cleanup:

- standardize on `jgoerzen/debian-base-standard:bullseye` for all images

- add `iputils-ping` to control node

- added the few packages that were in `jepsen.os.debian/setup!` but not yet in db node

- make all `apt-get update/install` formatting uniform

----

jepsen-io/etcd and a local test were used for testing on Debian.