### PR TITLE
doc: fix parse-long references across the tutorial.

### DIFF
--- a/doc/tutorial/03-client.md
+++ b/doc/tutorial/03-client.md
@@ -327,7 +327,7 @@ We can use that to determine the `:type` of the CaS operation.
 ```clj
   (invoke! [_ test op]
     (case (:f op)
-      :read  (assoc op :type :ok, :value (parse-long (v/get conn "foo")))
+      :read  (assoc op :type :ok, :value (parse-long-nil (v/get conn "foo")))
       :write (do (v/reset! conn "foo" (:value op))
                  (assoc op :type :ok))
       :cas (let [[old new] (:value op)]
@@ -375,7 +375,7 @@ error code.
 ```clj
     (invoke! [this test op]
       (case (:f op)
-        :read (assoc op :type :ok, :value (parse-long (v/get conn "foo")))
+        :read (assoc op :type :ok, :value (parse-long-nil (v/get conn "foo")))
         :write (do (v/reset! conn "foo" (:value op))
                    (assoc op :type :ok))
         :cas (try+

--- a/doc/tutorial/05-nemesis.md
+++ b/doc/tutorial/05-nemesis.md
@@ -166,7 +166,7 @@ that:
       (case (:f op)
         :read (let [value (-> conn
                               (v/get "foo" {:quorum? true})
-                              parse-long)]
+                              parse-long-nil)]
                 (assoc op :type :ok, :value value))
       ...
 ```

--- a/doc/tutorial/06-refining.md
+++ b/doc/tutorial/06-refining.md
@@ -44,7 +44,7 @@ safely convert crashed reads to failed reads, and improve checker performance.
     (case (:f op)
       :read  (try (let [value (-> conn
                                   (v/get "foo" {:quorum? true})
-                                  parse-long)]
+                                  parse-long-nil)]
                     (assoc op :type :ok, :value value))
                   (catch java.net.SocketTimeoutException ex
                     (assoc op :type :fail, :error :timeout)))
@@ -70,7 +70,7 @@ a little cleaner.
       (case (:f op)
         :read (let [value (-> conn
                               (v/get "foo" {:quorum? true})
-                              parse-long)]
+                              parse-long-nil)]
                 (assoc op :type :ok, :value value))
         :write (do (v/reset! conn "foo" (:value op))
                    (assoc op :type :ok))
@@ -163,7 +163,7 @@ keys.
         (case (:f op)
           :read (let [value (-> conn
                                 (v/get k {:quorum? true})
-                                parse-long)]
+                                parse-long-nil)]
                   (assoc op :type :ok, :value (independent/tuple k value)))
 
           :write (do (v/reset! conn k v)

--- a/doc/tutorial/07-parameters.md
+++ b/doc/tutorial/07-parameters.md
@@ -50,7 +50,7 @@ reads, in the Client `invoke` function:
         (case (:f op)
           :read (let [value (-> conn
                                 (v/get k {:quorum? (:quorum test)})
-                                parse-long)]
+                                parse-long-nil)]
                   (assoc op :type :ok, :value (independent/tuple k value)))
 ```
 


### PR DESCRIPTION
Hi again,

Tiny follow-up to #572. I forgot to update all the examples where `parse-long` was used, leaving the tutorial in an inconsistent state. (There is a joke to be made about eventual consistency here…) My sincerest apologies for that; this PR fixes it.

Cheers!