### PR TITLE
Tutorial: fix where parse-long is referenced without being defined

### DIFF
--- a/doc/tutorial/03-client.md
+++ b/doc/tutorial/03-client.md
@@ -281,6 +281,11 @@ function. It doesn't like being passed `nil`, though, so we'll write a small
 wrapper:
 
 ```clj
+(defn parse-long
+  "Parses a string to a Long."
+  [s]
+  (when s (Long/parseLong s)))
+
 (defn parse-long-nil
   "Parses a string to a Long. Passes through `nil`."
   [s]


### PR DESCRIPTION
In the original tutorial, parse-long is referenced but not defined.

The definition of parse-long has been added.