### PR TITLE
Fix typo in stolon nemesis.clj

### DIFF
--- a/stolon/src/jepsen/stolon/nemesis.clj
+++ b/stolon/src/jepsen/stolon/nemesis.clj
@@ -11,7 +11,7 @@
                             [time :as nt]]))
 
 (defn nemesis-package
-  "Constructs a nemesis and generators for MongoDB."
+  "Constructs a nemesis and generators for Stolon."
   [opts]
   (let [opts (update opts :faults set)]
     (nc/nemesis-package opts)))


### PR DESCRIPTION
Stolon is PostgreSQL HA tool. But `stolon/src/jepsen/stolon/nemesis.clj` says it is going to generate something for MongoDB, which i think is a typo