### PR TITLE
kafka: Fix checker worst-realtime-lag default value

### DIFF
--- a/jepsen/src/jepsen/tests/kafka.clj
+++ b/jepsen/src/jepsen/tests/kafka.clj
@@ -1563,7 +1563,7 @@
   "Takes a seq of realtime lag measurements, and finds the point with the
   highest lag."
   [lags]
-  (or (util/max-by :lag lags) 0))
+  (or (util/max-by :lag lags) {:time 0 :lag 0}))
 
 (defn key-order-viz
   "Takes a key, a log for that key (a vector of offsets to sets of elements
@@ -1994,7 +1994,7 @@
                (assoc errs :messages
                       (map-vals (comp (partial take 32) sort)
                                 (:messages errs))))
-     {:count (count errs)
+     {:count (if (coll? errs) (count errs) 1)
       :errs
       (if (:all-errors test)
         errs

--- a/jepsen/test/jepsen/tests/kafka_test.clj
+++ b/jepsen/test/jepsen/tests/kafka_test.clj
@@ -555,6 +555,18 @@
         (is (= {:time 22, :process 0, :key :x, :lag 17}
                (:worst-realtime-lag (analysis history))))))))
 
+(deftest empty-history-test
+  (let [history (h/history [(o 0 0 :invoke :assign [:x])
+                            (o 1 0 :ok :assign [:x])])
+        c (checker)
+        check (checker/check c
+                             {:name "empty-history-test"
+                              :start-time 0
+                              :history history}
+                             history
+                             nil)]
+    (is (not (:valid? check)))))
+
 (deftest unseen-test
   (is (= [{:time 1, :unseen {}}
           {:time 3, :unseen {:x 2}}


### PR DESCRIPTION
worst-realtime-lag used to give 0 as default but it's used as a map with :time and :lag keys. This change gives a default with both keys mapping to 0

Fixing that uncovers another problem in `condense-error`, sometimes the error values are not collections, eg with the provided test the error is `{:empty-transaction-graph true}`, and `count` can't be called on that.

See https://github.com/jepsen-io/maelstrom/issues/79 for more information.