### PR TITLE
update docker to bookworm, JDK21, deps, to support Jepsen 0.3.5-SNAPSHOT and latest MySQL and MariaDB tests

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,16 +1,20 @@
-FROM jgoerzen/debian-base-standard:bullseye
+FROM jgoerzen/debian-base-standard:bookworm
 
 ENV container=docker
 STOPSIGNAL SIGRTMIN+3
 
 ENV LEIN_ROOT true
 
+# JDK21 only in Debian testing
+RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
+ADD ./apt-preferences /etc/apt/preferences
+
 #
 # Jepsen dependencies
 #
 RUN apt-get -qy update && \
     apt-get -qy install \
-        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-17-jdk-headless pssh screen vim wget
+        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
 
 RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     mv lein /usr/bin && \

--- a/docker/control/apt-preferences
+++ b/docker/control/apt-preferences
@@ -1,0 +1,11 @@
+Package: *
+Pin: release a=stable
+Pin-Priority: 700
+
+Package: *
+Pin: release a=testing
+Pin-Priority: 650
+
+Package: *
+Pin: release a=unstable
+Pin-Priority: 600

--- a/docker/control/apt-preferences
+++ b/docker/control/apt-preferences
@@ -1,11 +1,3 @@
 Package: *
-Pin: release a=stable
-Pin-Priority: 700
-
-Package: *
 Pin: release a=testing
-Pin-Priority: 650
-
-Package: *
-Pin: release a=unstable
-Pin-Priority: 600
+Pin-Priority: 499

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,6 +1,6 @@
 # See https://salsa.debian.org/jgoerzen/docker-debian-base
 # See https://hub.docker.com/r/jgoerzen/debian-base-standard
-FROM jgoerzen/debian-base-standard:bullseye
+FROM jgoerzen/debian-base-standard:bookworm
 
 ENV container=docker
 STOPSIGNAL SIGRTMIN+3
@@ -29,7 +29,7 @@ ENV DEBBASE_SSH enabled
 # Install Jepsen deps
 RUN apt-get -qy update && \
     apt-get -qy install \
-        build-essential bzip2 ca-certificates curl dirmngr dnsutils faketime iproute2 iptables iputils-ping libzip4 logrotate man man-db netcat net-tools ntpdate psmisc python rsyslog sudo tar tcpdump unzip vim wget
+        build-essential bzip2 ca-certificates curl dirmngr dnsutils faketime iproute2 iptables iputils-ping libzip4 logrotate lsb-release man man-db netcat-openbsd net-tools ntpdate psmisc python3 rsyslog sudo tar tcpdump unzip vim wget
 
 EXPOSE 22
 CMD ["/usr/local/bin/boot-debian-base"]

--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -41,7 +41,7 @@ networks:
 
 services:
   setup:
-    image: jgoerzen/debian-base-standard:bullseye
+    image: jgoerzen/debian-base-standard:bookworm
     container_name: jepsen-setup
     hostname: setup
     volumes:


### PR DESCRIPTION
This PR updates the Docker environment:

  - Debian Bookworm
  - JDK21
  - misc deps
 
With the use of `java.util.SequencedCollection` it was necessary to update to JDK21.

It was tested using the recently released MySQL and MariaDB tests.
