### PR TITLE
change base image to work on m1 (closes #588)

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,4 +1,11 @@
-FROM jgoerzen/debian-base-standard:bookworm
+FROM jgoerzen/debian-base-minimal:bookworm as debian-addons
+FROM debian:bookworm-slim
+
+COPY --from=debian-addons /usr/local/preinit/ /usr/local/preinit/
+COPY --from=debian-addons /usr/local/bin/ /usr/local/bin/
+COPY --from=debian-addons /usr/local/debian-base-setup/ /usr/local/debian-base-setup/
+
+RUN run-parts --exit-on-error --verbose /usr/local/debian-base-setup
 
 ENV container=docker
 STOPSIGNAL SIGRTMIN+3

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,6 +1,13 @@
 # See https://salsa.debian.org/jgoerzen/docker-debian-base
 # See https://hub.docker.com/r/jgoerzen/debian-base-standard
-FROM jgoerzen/debian-base-standard:bookworm
+FROM jgoerzen/debian-base-minimal:bookworm as debian-addons
+FROM debian:bookworm-slim
+
+COPY --from=debian-addons /usr/local/preinit/ /usr/local/preinit/
+COPY --from=debian-addons /usr/local/bin/ /usr/local/bin/
+COPY --from=debian-addons /usr/local/debian-base-setup/ /usr/local/debian-base-setup/
+
+RUN run-parts --exit-on-error --verbose /usr/local/debian-base-setup
 
 ENV container=docker
 STOPSIGNAL SIGRTMIN+3


### PR DESCRIPTION
## source
The improved debian based images aren't build for arm64 out of the box but the official debian images are. We can follow `jgoerzen`'s guide to add these improvements to the official image

https://salsa.debian.org/jgoerzen/docker-debian-base-standard/-/tree/master?ref_type=heads#advanced-topic-adding-these-enhancements-to-other-images

## tests
- ensure `./docker/bin/up` works on an M1 (and also other machine types)

```ansi
❯ ./docker/bin/up
... more logs above
jepsen-n4       | [  OK  ] Started console-getty.service - Console Getty.
jepsen-n4       | [  OK  ] Reached target getty.target - Login Prompts.
jepsen-n4       | [  OK  ] Started ssh.service - OpenBSD Secure Shell server.
jepsen-n4       | [  OK  ] Started systemd-logind.service - User Login Management.
jepsen-n4       | [  OK  ] Reached target multi-user.target - Multi-User System.
jepsen-n4       | [  OK  ] Reached target graphical.target - Graphical Interface.
jepsen-n4       |          Starting systemd-update-ut… Record Runlevel Change in UTMP...
jepsen-n4       | [  OK  ] Finished systemd-update-ut… - Record Runlevel Change in UTMP.
jepsen-n5       | 
jepsen-n5       | Debian GNU/Linux 12 n5 console
jepsen-n5       | 
jepsen-n3       | 
jepsen-n3       | Debian GNU/Linux 12 n3 console
jepsen-n3       | 
jepsen-n1       | 
jepsen-n1       | Debian GNU/Linux 12 n1 console
jepsen-n1       | 
jepsen-n2       | 
jepsen-n2       | Debian GNU/Linux 12 n2 console
jepsen-n2       | 
jepsen-n4       | 
jepsen-n4       | Debian GNU/Linux 12 n4 console
jepsen-n4       | 
jepsen-control  | Welcome to Jepsen on Docker
jepsen-control  | ===========================
jepsen-control  | 
jepsen-control  | Please run `bin/console` in another terminal to proceed.
^CGracefully stopping... (press Ctrl+C again to force)
[+] Stopping 7/7
 ✔ Container jepsen-control  Stopped                                                                                   10.2s 
 ✔ Container jepsen-n2       Stopped                                                                                    0.5s 
 ✔ Container jepsen-n1       Stopped                                                                                    0.4s 
 ✔ Container jepsen-n5       Stopped                                                                                    0.5s 
 ✔ Container jepsen-n4       Stopped                                                                                    0.4s 
 ✔ Container jepsen-n3       Stopped                                                                                    0.5s 
 ✔ Container jepsen-setup    Stopped                                                                                    0.0s 
canceled

jepsen on git main [⇡] on ☁️  jacky@repl.it took 35s 
❯ uname -ms
Darwin arm64
```