### PR TITLE
explicitly use ipv4 addresses for hosts in `control.net/ip*`

### DIFF
--- a/jepsen/src/jepsen/control/net.clj
+++ b/jepsen/src/jepsen/control/net.clj
@@ -23,7 +23,7 @@
   ; 74.125.239.39   STREAM host.com
   ; 74.125.239.39   DGRAM
   ; ...
-  (let [res (c/exec :getent :ahosts host)
+  (let [res (c/exec :getent :ahostsv4 host)
         ip (first (str/split (->> res
                                   (str/split-lines)
                                   (first))


### PR DESCRIPTION
Hi,

Sometime in the last few months, installing:

  - Debian Bookworm
  - LXD + deps
  - Jepsen + deps
  - using defaults when possible 

changed `getent ahosts` behavior, (gives `systemd-resolved` some root cause extended side-eye :eyes: ), to at times return ipv6 addresses vs ipv4:

```bash
# changed default behavior
$ getent ahosts n1
fe80::216:3eff:fe6a:845f%3 STREAM n1
fe80::216:3eff:fe6a:845f%3 DGRAM  
fe80::216:3eff:fe6a:845f%3 RAW  
```

breaking the partition and packet nemeses as `iptables` and `tc filter` assume ipv4 and explicitly need an ipv6 option:

```txt
# iptables when partitioning
STDERR:  iptables v1.8.9 (nf_tables): host/network `fd42:860c:838f:2817:216:3eff:fe6c:d7c7' not found

# tc filter when packeting
STDERR:  Illegal "match"
```

This PR updates `control.net/ip*` to explicitly ask for ipv4 addresses  with `ahostsv4` vs using the default `ahosts`:

```bash
# explicit ipv4
$ getent ahostsv4 n1
10.82.244.5     STREAM n1
10.82.244.5     DGRAM  
10.82.244.5     RAW 
```

I also considered conditionally changing the partition and packet command lines based on interpreting the ip address, regex, but that felt clunky.

I think this change will be non-breaking as:

  - ipv4 only, or mixed ipv4/ipv6 environments that prefer ipv4 in the defaults -> same as existing behavior
  - mixed ipv4/ipv6 environments that prefer ipv6 -> will now use ipv4 for existing behavior
  - ipv6 only environments, tests already do not work and `control.net` would need to be multilingual

This has been tested on Debian Bookworm using LXD.

Thanks!
