### PR TITLE
jepsen.control.sshj: catch agent-not-found exceptions and continue trying other auth methods

### DIFF
--- a/jepsen/src/jepsen/control/sshj.clj
+++ b/jepsen/src/jepsen/control/sshj.clj
@@ -10,6 +10,7 @@
                             [scp :as scp]]
             [slingshot.slingshot :refer [try+ throw+]])
   (:import (com.jcraft.jsch.agentproxy AgentProxy
+                                       AgentProxyException
                                        ConnectorFactory)
            (com.jcraft.jsch.agentproxy.sshj AuthAgent)
            (net.schmizz.sshj SSHClient)
@@ -59,6 +60,8 @@
               methods (auth-methods agent-proxy)]
           (.auth c ^String username methods)
           true)
+        (catch AgentProxyException e
+          false)
         (catch UserAuthException e
           false))
 


### PR DESCRIPTION
The `auth!` method tries a few different approaches for authenticating, the second of which is via an ssh-agent. If the agent is found but not able to authenticate, that exception is caught so it can move on to trying other authentication methods. However if no agent is found, that exception is not caught, meaning we return early without trying subsequent methods.

This PR adds a catch for the agent-not-found exception as well so we move on to other auth methods, which should resolve #547.