### PR TITLE
Fixed error handling in jepsen.net/fast

### DIFF
--- a/jepsen/src/jepsen/net.clj
+++ b/jepsen/src/jepsen/net.clj
@@ -212,7 +212,7 @@
         (try
           (su (exec tc :qdisc :del :dev :eth0 :root))
           (catch RuntimeException e
-            (if (re-find #"RTNETLINK answers: No such file or directory"
+            (if (re-find #"Error: Cannot delete qdisc with handle of zero."
                          (.getMessage e))
               nil
               (throw e))))))


### PR DESCRIPTION
`net/sched/sch_api.c` in the Linux kernel changed the error message in 2017 with this commit: https://github.com/torvalds/linux/commit/09215598119ebf89bd204ca4ad8b7059266053d9. Hence, Jepsen's search for `No such file or directory" doesn't hold anymore. This change fixes this.

Relevant hunk from the commit: https://github.com/torvalds/linux/commit/09215598119ebf89bd204ca4ad8b7059266053d9#diff-ca8fc00def75b40f1f1bc2fb38e3949e5db262b93ceceb571f9138b98e3cc760R1323 