### PR TITLE
Fix catch with throw+ instead of throw

### DIFF
--- a/jepsen/src/jepsen/control/retry.clj
+++ b/jepsen/src/jepsen/control/retry.clj
@@ -30,7 +30,7 @@
          (if (pos? tries#)
            (do (Thread/sleep (+ (/ backoff-time 2) (rand-int backoff-time)))
                (~'retry (dec tries#)))
-           (throw e#))))))
+           (throw+ e#))))))
 
 (defrecord Remote [remote conn]
   core/Remote


### PR DESCRIPTION
The catch is in `try+`, which can catch other things than throwable. So use `throw+` to re-throw the exceptions.