### PR TITLE
docker/control installs JDK 21 manually

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -12,16 +12,13 @@ STOPSIGNAL SIGRTMIN+3
 
 ENV LEIN_ROOT true
 
-# JDK21 only in Debian testing
-RUN echo "deb http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
-ADD ./apt-preferences /etc/apt/preferences
-
 #
 # Jepsen dependencies
 #
 RUN apt-get -qy update && \
     apt-get -qy install \
-        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java openjdk-21-jdk-headless pssh screen vim wget
+        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java pssh screen vim wget && \
+    curl -L https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz | tar -xz --strip-components=1 -C /usr/local/
 
 RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     mv lein /usr/bin && \

--- a/docker/control/apt-preferences
+++ b/docker/control/apt-preferences
@@ -1,3 +1,0 @@
-Package: *
-Pin: release a=testing
-Pin-Priority: 499


### PR DESCRIPTION
The JDK21 hack doesn't work quite well (perhaps due to updates in upstream images).
Not sure if other folks face similar issues, but the changes here have fixed the builds on my side.