### PR TITLE
update checker/perf/rate-graph! to behave like checker/perf/point-graph!(latency-raw): elide empty [:f :type] values, use 1s bucket-times

### DIFF
--- a/jepsen/src/jepsen/checker/perf.clj
+++ b/jepsen/src/jepsen/checker/perf.clj
@@ -572,7 +572,7 @@
   "Writes a plot of operation rate by their completion times."
   [test history {:keys [subdirectory nemeses]}]
   (let [nemeses     (or nemeses (:nemeses (:plot test)))
-        dt          1
+        dt          10
         td          (double (/ dt))
         ; Times might technically be out-of-order (and our tests do this
         ; intentionally, just for convenience)


### PR DESCRIPTION
Hi,

This PR modifies `checker/perf/rate-graph!` to behave like `checker/perf/point-graph!`(latency-raw).

`checker/perf/point-graph!`(latency-raw):
  - elides empty `[:f :type]` values
  - uses 1s bucket-times

![image](https://github.com/user-attachments/assets/cd957101-96d5-44bf-b214-264fd83bd20e)

while the current `checker/perf/rate-graph!`
  - includes empty `[:f :type]` values
  - uses 10s bucket-times

![image](https://github.com/user-attachments/assets/90f5af6f-316f-4c95-b3fd-cbe2dac1ceee)
 
The inclusion of empty `[:f :type]` values:
  - clutters the graph
  - can invoke a negative initial response, e.g. Oh My God!, there's `:fail`s! `:info`s!
    - squints at graph, are they really 0's? or a need to look at `results.edn`? logs?
 
And the 10s bucket-time can mask a lot of variability in the actual rate, e.g. a challenging nemesis.

New `checker/perf/rate-graph!` with this PR:

![image](https://github.com/user-attachments/assets/164c0e47-eaaf-41d7-9f83-19753fd65aad)

The updated code for `rate-graph!` follows `point-graph!` 1 for 1.

Thanks!
