### PR TITLE
Update `apache.org` download link to use `closer.lua`

### DIFF
--- a/ignite/src/jepsen/ignite.clj
+++ b/ignite/src/jepsen/ignite.clj
@@ -64,7 +64,7 @@
   constructing one from the version."
   [test]
   (or (:url test)
-    (str "https://archive.apache.org/dist/ignite/"(:version test)"/apache-ignite-"(:version test)"-bin.zip")))
+    (str "https://www.apache.org/dyn/closer.lua/ignite/"(:version test)"/apache-ignite-"(:version test)"-bin.zip?action=download")))
 
 (defn start!
   "Starts server for the given node."


### PR DESCRIPTION
Update link to use `closer.lua` instead, as mentioned in [Apache's documentation](https://infra.apache.org/release-download-pages.html).