### PR TITLE
update Docker environment: privledged:true, latest JDK LTS

### DIFF
--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -17,8 +17,8 @@ ENV LEIN_ROOT true
 #
 RUN apt-get -qy update && \
     apt-get -qy install \
-        curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java pssh screen vim wget && \
-    curl -L https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz | tar -xz --strip-components=1 -C /usr/local/
+    curl dos2unix emacs git gnuplot graphviz htop iputils-ping libjna-java pssh screen vim wget && \
+    curl -L https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.8%2B9/OpenJDK21U-jdk_x64_linux_hotspot_21.0.8_9.tar.gz | tar -xz --strip-components=1 -C /usr/local/
 
 RUN wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein && \
     mv lein /usr/bin && \

--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -1,5 +1,6 @@
 x-node:
   &default-node
+  privileged: true
   build: ./node
   env_file: ./secret/node.env
   secrets:


### PR DESCRIPTION
Hi,

Finally cycling back as was mentioned in [PR #614](https://github.com/jepsen-io/jepsen/pull/614#issuecomment-2719375414) to update the Docker environment to run error free on an up to date Debian 12/Bookworm environment.

It appears that we've evolved, 🙃, back to needing `privileged: true` to successfully load all of the necessary kernel modules in the Docker container.

```yml
# docker/template/docker-compose.yml
privileged: true
```

This PR also updates to the latest LTS Java version, `OpenJDK 21.0.8_9 LTS`

```bash
$ bin/console 
Welcome to Jepsen on Docker
===========================

...

root@control:/jepsen# java --version
openjdk 21.0.8 2025-07-15 LTS
OpenJDK Runtime Environment Temurin-21.0.8+9 (build 21.0.8+9-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.8+9 (build 21.0.8+9-LTS, mixed mode, sharing)
```

As `java.net` URIs seem to end up at `oracle.com` these days, and the [Open JDK Wiki for JDK 21u](https://wiki.openjdk.org/display/JDKUpdates/JDK+21u) says to download binaries from `https://github.com/adoptium/temurin21-binaries/...`, that's the source that's used. IOW avoid Oracle.

Debian 13/Trixie is scheduled to be released on Aug 9th. I think LXD/LXC, `jepsen/os/debian`, and the Docker environments will need some updating then.

I know you've been hoping that the Docker environment would be removed from the Jepsen repository for some time.
Maybe the new Debian release would be a natural time to explore, do that.

Thanks!
