### PR TITLE
jepsen.control.util/ls-full: fix typo, mark deprecated, and change uses of ls-full to ls

### DIFF
--- a/jepsen/src/jepsen/control/util.clj
+++ b/jepsen/src/jepsen/control/util.clj
@@ -96,13 +96,13 @@
      ; Find's traversal order is by inode structure, so we sort for stability
      (sort paths))))
 
-(defn ls-full
-  "Like ls, but prepends dir to each entry. TODO: deprecate this in favor of ls
-  {:full-path? true}."
+(defn ^:deprecated ls-full
+  "Deprecated, use `(ls dir {:full-path? true})`."
   ([] (ls-full "."))
   ([dir] (ls-full dir {}))
   ([dir opts]
-   (ls dir (assoc opts {:full-path? true}))))
+   (let [opts (assoc opts :full-path? true)]
+     (ls dir opts))))
 
 (defn tmp-file!
   "Creates a random, temporary file under tmp-dir-base, and returns its path.

--- a/jepsen/src/jepsen/nemesis.clj
+++ b/jepsen/src/jepsen/nemesis.clj
@@ -580,7 +580,7 @@
                                  _ (assert (integer? drop))
                                  file (if (cu/file? file)
                                         file
-                                        (rand/nth (cu/ls-full file)))]
+                                        (rand/nth (cu/ls file {:recursive? true :types [:file] :full-path? true})))]
                              (c/su
                               (c/exec :truncate :-c :-s (str "-" drop) file))
                              {:file file :drop drop})))
@@ -613,7 +613,7 @@
                                  (throw+ {:type ::no-file}))
                              file (if (cu/file? file)
                                     file
-                                    (rand/nth (cu/ls-full file)))
+                                    (rand/nth (cu/ls file {:recursive? true :types [:file] :full-path? true})))
                              probability (or probability 0.01)
                              percent (* 100 probability)]
                          (c/su


### PR DESCRIPTION
Hi,

Using the `bitflip` Nemesis exposed a bug that was introduced in [Commit 0479c46](https://github.com/nurturenature/jepsen/commit/0479c464227afa70378e392681e879e536a18c04).

This PR fixes the typo in `jepsen.control.util/ls-full`.

And as the original `ls-full` docstring said "TODO: deprecate this in favor of ls {:full-path? true}"

- marks `ls-full` as `^:deprecated`
- changes the two uses of `ls-full` in Jepsen to `ls`

Also, I think it reads more closely to the Nemesis' intent, corrupt a random file from the given directory

```clj
(rand/nth (cu/ls file {:recursive? true :types [:file] :full-path? true}))
```

Thanks!